### PR TITLE
카페 리스트 페이지 백엔드 API 연결 및 무한스크롤 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "codebrew",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.64.1",
         "@vanilla-extract/css": "^1.17.0",
         "@vanilla-extract/recipes": "^0.5.5",
         "next": "15.0.3",
@@ -3287,6 +3288,30 @@
       "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.64.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.64.1.tgz",
+      "integrity": "sha512-978Wx4Wl4UJZbmvU/rkaM9cQtXXrbhK0lsz/UZhYIbyKYA8E4LdomTwyh2GHZ4oU0BKKoDH4YlKk2VscCUgNmg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.64.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.64.1.tgz",
+      "integrity": "sha512-vW5ggHpIO2Yjj44b4sB+Fd3cdnlMJppXRBJkEHvld6FXh3j5dwWJoQo7mGtKI2RbSFyiyu/PhGAy0+Vv5ev9Eg==",
+      "dependencies": {
+        "@tanstack/query-core": "5.64.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@trysound/sax": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
         "@vanilla-extract/css": "^1.17.0",
         "@vanilla-extract/recipes": "^0.5.5",
         "next": "15.0.3",
-        "react": "19.0.0-rc-66855b96-20241106",
-        "react-dom": "19.0.0-rc-66855b96-20241106"
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "@svgr/webpack": "^8.1.0",
@@ -6587,8 +6587,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -6778,7 +6777,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -7394,22 +7392,26 @@
       }
     },
     "node_modules/react": {
-      "version": "19.0.0-rc-66855b96-20241106",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0-rc-66855b96-20241106.tgz",
-      "integrity": "sha512-klH7xkT71SxRCx4hb1hly5FJB21Hz0ACyxbXYAECEqssUjtJeFUAaI2U1DgJAzkGEnvEm3DkxuBchMC/9K4ipg==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.0.0-rc-66855b96-20241106",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0-rc-66855b96-20241106.tgz",
-      "integrity": "sha512-D25vdaytZ1wFIRiwNU98NPQ/upS2P8Co4/oNoa02PzHbh8deWdepjm5qwZM/46OdSiGv4WSWwxP55RO9obqJEQ==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dependencies": {
-        "scheduler": "0.25.0-rc-66855b96-20241106"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "19.0.0-rc-66855b96-20241106"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-is": {
@@ -7734,9 +7736,12 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.25.0-rc-66855b96-20241106",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-66855b96-20241106.tgz",
-      "integrity": "sha512-HQXp/Mnp/MMRSXMQF7urNFla+gmtXW/Gr1KliuR0iboTit4KvZRY8KYaq5ccCTAOJiUqQh2rE2F3wgUekmgdlA=="
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.64.1",
     "@vanilla-extract/css": "^1.17.0",
     "@vanilla-extract/recipes": "^0.5.5",
     "next": "15.0.3",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "@vanilla-extract/css": "^1.17.0",
     "@vanilla-extract/recipes": "^0.5.5",
     "next": "15.0.3",
-    "react": "19.0.0-rc-66855b96-20241106",
-    "react-dom": "19.0.0-rc-66855b96-20241106"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",

--- a/src/apis/cafe.ts
+++ b/src/apis/cafe.ts
@@ -1,0 +1,30 @@
+import { ROUTE_PATH } from '@/constants/routePath';
+import type { Cafe, Region } from '@/types';
+import type { QueryFunctionContext } from '@tanstack/react-query';
+
+export interface CafeListResponse {
+  result: Cafe[];
+  hasNext: boolean;
+}
+
+const BASE_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+export const getCafes = async ({
+  pageParam,
+}: QueryFunctionContext<['cafes', Region], string | undefined>): Promise<CafeListResponse> => {
+  const url = new URL(`${BASE_URL}${ROUTE_PATH.cafes}`);
+
+  if (pageParam) {
+    url.searchParams.append('lastCafeId', pageParam);
+  }
+
+  const response = await fetch(url.toString());
+
+  if (!response.ok) {
+    throw new Error('cafes를 불러오는 중 예기치 못한 오류가 발생했습니다.');
+  }
+
+  const data = await response.json();
+
+  return data.data;
+};

--- a/src/app/cafes/page.tsx
+++ b/src/app/cafes/page.tsx
@@ -2,15 +2,17 @@
 
 import { useState } from 'react';
 import CafeList from '@/components/cafes/CafeList';
-import MOCK_CAFE_LIST from '@/mock/cafeList.json';
 import type { Region } from '@/types';
 import RegionSelectModal from '@/components/cafes/RegionSelectModal';
 import RegionSelectButtons from '@/components/cafes/RegionSelectButtons';
 import { REGIONS } from '@/constants/region';
+import { useInfiniteCafes } from '@/hooks/server/useInfiniteCafes';
+import { IntersectionDetector } from '@/components/common/IntersectionDetector';
 
 export default function Page() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [region, setRegion] = useState<Region>(REGIONS.전체);
+  const { fetchNextPage, data } = useInfiniteCafes(region);
 
   const resetRegion = () => {
     setRegion(REGIONS.전체);
@@ -27,7 +29,8 @@ export default function Page() {
   return (
     <div>
       <RegionSelectButtons region={region} resetRegion={resetRegion} openModal={openModal} />
-      <CafeList cafeList={MOCK_CAFE_LIST} />
+      <CafeList cafeList={data} />
+      <IntersectionDetector onIntersected={fetchNextPage} />
       <RegionSelectModal
         isOpen={isModalOpen}
         region={region}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${pretendard.className} `}>
-        <div className={`${rootContainer}`}>
+        <div id="root" className={`${rootContainer}`}>
           <Providers>{children}</Providers>
           <div id="modal-root"></div>
         </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import { rootContainer } from './layout.css';
 import { DotGothic16 } from 'next/font/google';
 import localFont from 'next/font/local';
+import Providers from './providers';
 
 const pretendard = localFont({
   src: '../fonts/PretendardVariable.woff2',
@@ -26,7 +27,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${pretendard.className} `}>
         <div className={`${rootContainer}`}>
-          {children}
+          <Providers>{children}</Providers>
           <div id="modal-root"></div>
         </div>
       </body>

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { isServer, QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+      },
+    },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+function getQueryClient() {
+  if (isServer) {
+    return makeQueryClient();
+  } else {
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+}
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  const queryClient = getQueryClient();
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/src/components/cafes/CafeItem.tsx
+++ b/src/components/cafes/CafeItem.tsx
@@ -22,7 +22,7 @@ export default function CafeItem({ cafe }: CafeItemProps) {
   const { id, name, location, tags, images } = cafe;
 
   return (
-    <Link href={`${ROUTE_PATH.cafe}/${id}`}>
+    <Link href={`${ROUTE_PATH.cafes}/${id}`}>
       <div>
         <div className={cafeItemHeading}>
           <div className={cafeItemName}>{name}</div>

--- a/src/components/cafes/CafeItem.tsx
+++ b/src/components/cafes/CafeItem.tsx
@@ -19,21 +19,21 @@ interface CafeItemProps {
 }
 
 export default function CafeItem({ cafe }: CafeItemProps) {
-  const { id, name, location, tags, images } = cafe;
+  const { id, name, nearestStation, tag: tags, previewImages } = cafe;
 
   return (
     <Link href={`${ROUTE_PATH.cafes}/${id}`}>
       <div>
         <div className={cafeItemHeading}>
           <div className={cafeItemName}>{name}</div>
-          <div className={cafeLocation}>{location}</div>
+          <div className={cafeLocation}>{nearestStation}</div>
         </div>
         <div className={tagList}>
           {tags.map((tag, index) => (
             <TemporaryTag key={`${name}-tag-${index}`} name={tag.name} />
           ))}
         </div>
-        <CafeImageList cafeName={name} images={images} />
+        <CafeImageList cafeName={name} images={previewImages} />
       </div>
     </Link>
   );

--- a/src/components/common/IntersectionDetector/hooks/useIntersectionObserver.ts
+++ b/src/components/common/IntersectionDetector/hooks/useIntersectionObserver.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+type TargetSetter = (target: Element | null) => void;
+
+const useIntersectionObserver = (onIntersected: () => void): TargetSetter => {
+  const [target, setTarget] = useState<Element | null>(null);
+
+  useEffect(() => {
+    if (!target) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          onIntersected();
+        }
+      },
+      {
+        root: document.getElementById('root'),
+        rootMargin: '200px',
+      }
+    );
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [target, onIntersected]);
+
+  return setTarget;
+};
+
+export default useIntersectionObserver;

--- a/src/components/common/IntersectionDetector/index.tsx
+++ b/src/components/common/IntersectionDetector/index.tsx
@@ -1,0 +1,11 @@
+import useIntersectionObserver from './hooks/useIntersectionObserver';
+
+interface IntersectionDetectorProps {
+  onIntersected: () => void;
+}
+
+export const IntersectionDetector = ({ onIntersected }: IntersectionDetectorProps) => {
+  const setTarget = useIntersectionObserver(onIntersected);
+
+  return <div ref={setTarget} />;
+};

--- a/src/constants/routePath.ts
+++ b/src/constants/routePath.ts
@@ -1,3 +1,3 @@
 export const ROUTE_PATH = {
-  cafe: '/cafe',
+  cafes: '/cafes',
 };

--- a/src/hooks/server/useInfiniteCafes.ts
+++ b/src/hooks/server/useInfiniteCafes.ts
@@ -1,0 +1,39 @@
+import { type CafeListResponse, getCafes } from '@/apis/cafe';
+import type { Region } from '@/types';
+import { DefaultError, InfiniteData, useInfiniteQuery } from '@tanstack/react-query';
+
+export const useInfiniteCafes = (region: Region) => {
+  const queryResult = useInfiniteQuery<
+    CafeListResponse,
+    DefaultError,
+    InfiniteData<CafeListResponse>,
+    ['cafes', Region],
+    string | undefined
+  >({
+    queryKey: ['cafes', region],
+    queryFn: getCafes,
+    getNextPageParam: getLastCafeId,
+    initialPageParam: undefined,
+    throwOnError: true,
+  });
+
+  return {
+    ...queryResult,
+    data: queryResult.data?.pages.flatMap((page) => page.result) || [],
+    fetchNextPage: () => {
+      if (!queryResult.isLoading && !queryResult.isFetchingNextPage) {
+        queryResult.fetchNextPage();
+      }
+    },
+  };
+};
+
+function getLastCafeId(lastPage: CafeListResponse) {
+  if (!lastPage.hasNext) {
+    return;
+  }
+
+  const lastCafeId = lastPage.result.at(-1)?.id;
+
+  return lastCafeId;
+}

--- a/src/mock/cafeList.json
+++ b/src/mock/cafeList.json
@@ -1,9 +1,9 @@
 [
   {
-    "id": 2,
+    "id": "1",
     "name": "헤베커피",
-    "location": "충무로역 근처",
-    "tags": [
+    "nearestStation": "충무로역",
+    "tag": [
       {
         "id": 1,
         "name": "전문 바리스타"
@@ -21,13 +21,16 @@
         "name": "시그니처"
       }
     ],
-    "images": ["https://placehold.co/200x200?text=Cafe1"]
+    "previewImages": ["https://placehold.co/200x200?text=Cafe1"],
+    "location": "string",
+    "price": 0,
+    "mainImages": "string"
   },
   {
-    "id": 1,
-    "name": "헤베커피",
-    "location": "충무로역 근처",
-    "tags": [
+    "id": "2",
+    "name": "헤베커피2",
+    "nearestStation": "공덕역",
+    "tag": [
       {
         "id": 1,
         "name": "전문 바리스타"
@@ -45,13 +48,19 @@
         "name": "시그니처"
       }
     ],
-    "images": ["https://placehold.co/200x200?text=Cafe1", "https://placehold.co/200x200?text=Cafe3"]
+    "previewImages": [
+      "https://placehold.co/200x200?text=Cafe1",
+      "https://placehold.co/200x200?text=Cafe3"
+    ],
+    "location": "string",
+    "price": 0,
+    "mainImages": "string"
   },
   {
-    "id": 4,
-    "name": "헤베커피",
-    "location": "충무로역 근처",
-    "tags": [
+    "id": "3",
+    "name": "헤베커피3",
+    "nearestStation": "홍대역",
+    "tag": [
       {
         "id": 1,
         "name": "전문 바리스타"
@@ -63,39 +72,22 @@
       {
         "id": 3,
         "name": "드립커피"
-      },
-      {
-        "id": 4,
-        "name": "시그니처"
-      },
-      {
-        "id": 5,
-        "name": "시그니처"
-      },
-      {
-        "id": 6,
-        "name": "시그니처"
-      },
-      {
-        "id": 7,
-        "name": "시그니처"
-      },
-      {
-        "id": 8,
-        "name": "시그니처"
       }
     ],
-    "images": [
+    "previewImages": [
       "https://placehold.co/200x200?text=Cafe1",
       "https://placehold.co/200x200?text=Cafe2",
       "https://placehold.co/200x200?text=Cafe3"
-    ]
+    ],
+    "location": "string",
+    "price": 0,
+    "mainImages": "string"
   },
   {
-    "id": 3,
-    "name": "헤베커피",
-    "location": "충무로역 근처",
-    "tags": [
+    "id": "4",
+    "name": "헤베커피4",
+    "nearestStation": "충무로역",
+    "tag": [
       {
         "id": 1,
         "name": "전문 바리스타"
@@ -113,11 +105,14 @@
         "name": "시그니처"
       }
     ],
-    "images": [
+    "previewImages": [
       "https://placehold.co/200x200?text=Cafe1",
       "https://placehold.co/200x200?text=Cafe2",
       "https://placehold.co/200x200?text=Cafe3",
       "https://placehold.co/200x200?text=Cafe4"
-    ]
+    ],
+    "location": "string",
+    "price": 0,
+    "mainImages": "string"
   }
 ]

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,10 @@
 import { REGIONS } from '@/constants/region';
 export interface Cafe {
-  id: number;
+  id: string;
   name: string;
-  location: string;
-  tags: { id: number; name: string }[];
-  images: string[];
+  nearestStation: string;
+  tag: { id: number; name: string }[];
+  previewImages: string[];
 }
 
 export type Region = (typeof REGIONS)[keyof typeof REGIONS];


### PR DESCRIPTION
## 작업 내용
카페 리스트 페이지에 대해 백엔드 API를 연결하고 및 무한스크롤을 구현합니다.

주요 작업 사항은 다음과 같습니다.
- tanstack-query 세팅
- getCafes 구현
- useInfiniteCafes 구현
- 무한스크롤 하단 영역 감지를 위한 IntersectionDetector 구현

## 참고
1. 프로젝트 root의`.env` 파일에 아래와 같이 추가해주세요.
```
NEXT_PUBLIC_BACKEND_URL=http://서버주소/v1/api
```

2. 우선 내일 발표를 위한 영상 촬영을 위해 작업을 빠르게 마무리했습니다. 이후에 아래 사항들에 대해 고민하고 적용해볼 계획입니다.
  - 백엔드 기능 추가 이후 지역 선택에 따른 데이터 불러오기 기능 추가
  - useInfiniteCafes 리팩토링
	- queryKey 관리 방식 고민하기
  - 서버 데이터와 UI 사이의 데이터 가공 레이어 두기?
  - fetch 추상화하기

## 연관 이슈

- close #15
