### PR TITLE
카페 리스트 페이지 프로덕션 api 연동 및 자잘한 수정

### DIFF
--- a/src/apis/cafe.ts
+++ b/src/apis/cafe.ts
@@ -3,7 +3,7 @@ import type { Cafe, Region } from '@/types';
 import type { QueryFunctionContext } from '@tanstack/react-query';
 
 export interface CafeListResponse {
-  result: Cafe[];
+  cafes: Cafe[];
   hasNext: boolean;
 }
 

--- a/src/app/cafes/page.tsx
+++ b/src/app/cafes/page.tsx
@@ -12,7 +12,8 @@ import { IntersectionDetector } from '@/components/common/IntersectionDetector';
 export default function Page() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [region, setRegion] = useState<Region>(REGIONS.전체);
-  const { fetchNextPage, data } = useInfiniteCafes(region);
+  const { fetchNextPage, data, hasNextPage } = useInfiniteCafes(region);
+  console.log('page');
 
   const resetRegion = () => {
     setRegion(REGIONS.전체);
@@ -30,7 +31,7 @@ export default function Page() {
     <div>
       <RegionSelectButtons region={region} resetRegion={resetRegion} openModal={openModal} />
       <CafeList cafeList={data} />
-      <IntersectionDetector onIntersected={fetchNextPage} />
+      <IntersectionDetector onIntersected={fetchNextPage} isOff={!hasNextPage} />
       <RegionSelectModal
         isOpen={isModalOpen}
         region={region}

--- a/src/app/cafes/page.tsx
+++ b/src/app/cafes/page.tsx
@@ -13,7 +13,6 @@ export default function Page() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [region, setRegion] = useState<Region>(REGIONS.전체);
   const { fetchNextPage, data, hasNextPage } = useInfiniteCafes(region);
-  console.log('page');
 
   const resetRegion = () => {
     setRegion(REGIONS.전체);

--- a/src/assets/Icon/closeIcon.svg
+++ b/src/assets/Icon/closeIcon.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 6L6 18M18 18L6 6" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/src/components/cafes/CafeItem.tsx
+++ b/src/components/cafes/CafeItem.tsx
@@ -11,8 +11,8 @@ import {
   cafeItemName,
   cafeLocation,
   tagList,
-  temporaryTag,
 } from './cafes.css';
+import HashTag from '../common/HashTag';
 
 interface CafeItemProps {
   cafe: Cafe;
@@ -30,7 +30,7 @@ export default function CafeItem({ cafe }: CafeItemProps) {
         </div>
         <div className={tagList}>
           {tags?.map((tag, index) => (
-            <TemporaryTag key={`${name}-tag-${index}`} name={tag.name} />
+            <HashTag key={`${name}-tag-${index}`}>{tag.name}</HashTag>
           ))}
         </div>
         <CafeImageList cafeName={name} images={previewImages} />
@@ -60,9 +60,4 @@ function CafeImageList({ cafeName, images }: { cafeName: string; images: string[
       {isOverflow && <div className={overflowCafeImageCount}>+{overflowImageCount}</div>}
     </div>
   );
-}
-
-// 유빈 공통 컴포넌트 구현 뒤 대체 예정
-function TemporaryTag({ name }: { name: string }) {
-  return <div className={temporaryTag}>{name}</div>;
 }

--- a/src/components/cafes/CafeItem.tsx
+++ b/src/components/cafes/CafeItem.tsx
@@ -19,17 +19,17 @@ interface CafeItemProps {
 }
 
 export default function CafeItem({ cafe }: CafeItemProps) {
-  const { id, name, nearestStation, tag: tags, previewImages } = cafe;
+  const { cafeId, name, nearestStation, tags, previewImages } = cafe;
 
   return (
-    <Link href={`${ROUTE_PATH.cafes}/${id}`}>
+    <Link href={`${ROUTE_PATH.cafes}/${cafeId}`}>
       <div>
         <div className={cafeItemHeading}>
           <div className={cafeItemName}>{name}</div>
           <div className={cafeLocation}>{nearestStation}</div>
         </div>
         <div className={tagList}>
-          {tags.map((tag, index) => (
+          {tags?.map((tag, index) => (
             <TemporaryTag key={`${name}-tag-${index}`} name={tag.name} />
           ))}
         </div>
@@ -40,16 +40,19 @@ export default function CafeItem({ cafe }: CafeItemProps) {
 }
 
 const MAX_IMAGE_COUNT = 3;
+const DEFAULT_CAFE_IMAGE = 'https://placehold.co/200x200?text=Coffee Lounge';
 
 function CafeImageList({ cafeName, images }: { cafeName: string; images: string[] }) {
   const overflowImageCount = images.length - MAX_IMAGE_COUNT;
   const isOverflow = overflowImageCount > 0;
 
-  const slicedImages = images.slice(0, MAX_IMAGE_COUNT);
+  const isEmpty = images.length === 0;
+
+  const displayingImages = isEmpty ? [DEFAULT_CAFE_IMAGE] : images.slice(0, MAX_IMAGE_COUNT);
 
   return (
     <div className={cafeImageList}>
-      {slicedImages.map((src, index) => (
+      {displayingImages.map((src, index) => (
         <div className={cafeImageWrapper} key={`${cafeName}-image-${index}`}>
           <Image fill className={cafeImage} alt={`${cafeName} ${index + 1}번째 사진`} src={src} />
         </div>

--- a/src/components/cafes/CafeList.tsx
+++ b/src/components/cafes/CafeList.tsx
@@ -10,7 +10,7 @@ export default function CafeList({ cafeList }: CafeListProps) {
   return (
     <ul className={cafeListContainer}>
       {cafeList.map((cafe) => (
-        <li key={cafe.id}>
+        <li key={cafe.cafeId}>
           <CafeItem cafe={cafe} />
         </li>
       ))}

--- a/src/components/cafes/RegionSelectModal/RegionSelectModal.css.ts
+++ b/src/components/cafes/RegionSelectModal/RegionSelectModal.css.ts
@@ -1,19 +1,10 @@
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
-import { color } from '@/styles/color.css';
-import { body1, body1Bold, button1, title3 } from '@/styles/typo.css';
+import { body1, body1Bold } from '@/styles/typo.css';
 
 export const regionSelectModalContent = style({
   display: 'flex',
   flexDirection: 'column',
-});
-
-export const regionSelectModalTitle = style({
-  ...title3,
-  color: color.grayScale.gray500,
-  padding: '2.4rem 0 1.2rem 2rem',
-  display: 'flex',
-  alignItems: 'center',
 });
 
 export const regionItem = recipe({
@@ -24,7 +15,6 @@ export const regionItem = recipe({
     height: '5.6rem',
     cursor: 'pointer',
     width: '100%',
-    padding: '0 2rem 0 2rem',
   },
 
   variants: {
@@ -33,19 +23,4 @@ export const regionItem = recipe({
       false: body1,
     },
   },
-});
-
-export const closeButtonWrapper = style({
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  borderTop: '1px solid #eeeeee',
-  height: '4.7rem',
-  marginBottom: '1.6rem',
-});
-
-export const closeButton = style({
-  ...button1,
-  cursor: 'pointer',
-  width: '100%',
 });

--- a/src/components/cafes/RegionSelectModal/RegionSelectModalContent.tsx
+++ b/src/components/cafes/RegionSelectModal/RegionSelectModalContent.tsx
@@ -1,12 +1,6 @@
 import { REGIONS } from '@/constants/region';
 import type { Region } from '@/types';
-import {
-  closeButton,
-  closeButtonWrapper,
-  regionItem,
-  regionSelectModalContent,
-  regionSelectModalTitle,
-} from './RegionSelectModal.css';
+import { regionItem, regionSelectModalContent } from './RegionSelectModal.css';
 import CheckIcon from '@/assets/checkIcon.svg';
 
 interface RegionSelectModalContentProps {
@@ -24,7 +18,6 @@ export default function RegionSelectModalContent({
 
   return (
     <div className={regionSelectModalContent}>
-      <h1 className={regionSelectModalTitle}>지역별</h1>
       <ul>
         {regions.map((region) => {
           const isSelected = region === selectedRegion;
@@ -42,11 +35,6 @@ export default function RegionSelectModalContent({
           );
         })}
       </ul>
-      <div className={closeButtonWrapper}>
-        <button className={closeButton} onClick={onClose}>
-          닫기
-        </button>
-      </div>
     </div>
   );
 }

--- a/src/components/cafes/RegionSelectModal/index.tsx
+++ b/src/components/cafes/RegionSelectModal/index.tsx
@@ -16,7 +16,7 @@ export default function RegionSelectModal({
   onClose,
 }: RegionSelectModalProps) {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} position="bottom">
+    <Modal title="지역별" isOpen={isOpen} onClose={onClose} position="bottom">
       <RegionSelectModalContent selectedRegion={region} setRegion={setRegion} onClose={onClose} />
     </Modal>
   );

--- a/src/components/cafes/cafes.css.ts
+++ b/src/components/cafes/cafes.css.ts
@@ -53,14 +53,6 @@ export const overflowCafeImageCount = style({
   lineHeight: '3.6rem',
 });
 
-export const temporaryTag = style({
-  backgroundColor: '#ECECEC80',
-  width: 'fit-content',
-  padding: '0.3rem 0.6rem',
-  borderRadius: '0.4rem',
-  lineHeight: '2.2rem',
-});
-
 // CafeList
 export const cafeListContainer = style({
   padding: '2.4rem 2rem',

--- a/src/components/common/IntersectionDetector/hooks/useIntersectionObserver.ts
+++ b/src/components/common/IntersectionDetector/hooks/useIntersectionObserver.ts
@@ -25,7 +25,7 @@ const useIntersectionObserver = (onIntersected: () => void): TargetSetter => {
     return () => {
       observer.disconnect();
     };
-  }, [target, onIntersected]);
+  }, [target]);
 
   return setTarget;
 };

--- a/src/components/common/IntersectionDetector/index.tsx
+++ b/src/components/common/IntersectionDetector/index.tsx
@@ -2,10 +2,15 @@ import useIntersectionObserver from './hooks/useIntersectionObserver';
 
 interface IntersectionDetectorProps {
   onIntersected: () => void;
+  isOff?: boolean;
 }
 
-export const IntersectionDetector = ({ onIntersected }: IntersectionDetectorProps) => {
+export const IntersectionDetector = ({ onIntersected, isOff }: IntersectionDetectorProps) => {
   const setTarget = useIntersectionObserver(onIntersected);
+
+  if (isOff) {
+    return null;
+  }
 
   return <div ref={setTarget} />;
 };

--- a/src/components/common/Modal/Modal.css.ts
+++ b/src/components/common/Modal/Modal.css.ts
@@ -1,3 +1,5 @@
+import { color } from '@/styles/color.css';
+import { title3 } from '@/styles/typo.css';
 import { style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
@@ -10,7 +12,20 @@ export const modal = style({
   },
 });
 
-export const modalContent = recipe({
+export const modalTitle = style({
+  ...title3,
+  color: color.grayScale.gray500,
+  padding: '2.4rem 2rem 1.2rem 2rem',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+});
+
+export const closeIcon = style({
+  cursor: 'pointer',
+});
+
+export const modalContainer = recipe({
   base: {
     maxWidth: '50rem',
     width: '100%',
@@ -33,4 +48,8 @@ export const modalContent = recipe({
       },
     },
   },
+});
+
+export const modalContent = style({
+  padding: '1.6rem 2rem 2.4rem 2rem',
 });

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -3,19 +3,22 @@
 import { PropsWithChildren } from 'react';
 import { createPortal } from 'react-dom';
 import { useModal } from './hooks/useModal';
-import { modal, modalContent } from './Modal.css';
+import { closeIcon, modal, modalContainer, modalContent, modalTitle } from './Modal.css';
+import CloseIcon from '@/assets/Icon/closeIcon.svg';
 
 export type ModalPosition = 'center' | 'bottom';
 
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
+  title: string;
   position?: ModalPosition;
 }
 
 export default function Modal({
   isOpen,
   onClose,
+  title,
   position = 'center',
   children,
 }: PropsWithChildren<ModalProps>) {
@@ -27,7 +30,13 @@ export default function Modal({
 
   return createPortal(
     <dialog ref={dialogRef} onClose={onClose} onClick={onClickDialog} className={modal}>
-      <div className={modalContent({ position })}>{children}</div>
+      <div className={modalContainer({ position })}>
+        <h1 className={modalTitle}>
+          <span>{title}</span>
+          <CloseIcon onClick={onClose} className={closeIcon} />
+        </h1>
+        <div className={modalContent}>{children}</div>
+      </div>
     </dialog>,
     targetContainer
   );

--- a/src/hooks/server/useInfiniteCafes.ts
+++ b/src/hooks/server/useInfiniteCafes.ts
@@ -19,7 +19,7 @@ export const useInfiniteCafes = (region: Region) => {
 
   return {
     ...queryResult,
-    data: queryResult.data?.pages.flatMap((page) => page.result) || [],
+    data: queryResult.data?.pages.flatMap((page) => page.cafes) || [],
     fetchNextPage: () => {
       if (!queryResult.isLoading && !queryResult.isFetchingNextPage) {
         queryResult.fetchNextPage();
@@ -33,7 +33,7 @@ function getLastCafeId(lastPage: CafeListResponse) {
     return;
   }
 
-  const lastCafeId = lastPage.result.at(-1)?.id;
+  const lastCafeId = lastPage.cafes.at(-1)?.cafeId;
 
   return lastCafeId;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,10 @@
 import { REGIONS } from '@/constants/region';
+
 export interface Cafe {
-  id: string;
+  cafeId: string;
   name: string;
   nearestStation: string;
-  tag: { id: number; name: string }[];
+  tags: { id: string; name: string }[];
   previewImages: string[];
 }
 


### PR DESCRIPTION
## 작업 내용
- 카페 리스트 페이지 프로덕션 api 연동을 위해 인터페이스를 수정했습니다.
- 자잘하게 여러가지를 수정을 했습니다
  - 다음 페이지가 없을 경우 `IntersectionDetector` 작동을 멈추도록 수정
  - 디자인 시스템에 맞게 모달 수정 (닫기 버튼 추가 / title 추가 / 컨텐츠 레이아웃 스타일링)
  - 카페 이미지 없을 경우 대체 이미지 사용

## 참고
이번 PR 머지되면 카페 리스트는 배포 준비 완료입니다. 예정대로 배포 진행하셔도 될 것 같아요.
(배포 시에 vercel 환경변수에 `NEXT_PUBLIC_BACKEND_URL`에 백엔드 url(`/api/v1` 포함) 넣어주셔야 합니다.)

## 연관 이슈

- close #20
