### PR TITLE
feat: 메인 페이지 및 카페 리스트 페이지 스크롤 복원 구현

### DIFF
--- a/src/app/(detail)/cafes/[id]/page.tsx
+++ b/src/app/(detail)/cafes/[id]/page.tsx
@@ -2,7 +2,7 @@ import { getCafeDetail } from '@/apis/cafeDetail';
 import ChevronLeft from '@/assets/Icon/Chevron_Left.svg';
 import BackButton from '@/components/cafes/[id]/BackButton';
 import BookMarkButton from '@/components/cafes/[id]/BookMarkButton';
-// import FlavorList from '@/components/cafes/[id]/FlavorItem';
+import FlavorList from '@/components/cafes/[id]/FlavorItem';
 import Footer from '@/components/cafes/[id]/Footer';
 import IconWithHashTag from '@/components/cafes/[id]/IconWithHashTag';
 import MapButton from '@/components/cafes/[id]/MapButton';
@@ -90,7 +90,7 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
             </div>
             <div>
               <h3>향미</h3>
-              {/* <FlavorList flavors={coffeeBean.flavors} /> */}
+              <FlavorList flavors={coffeeBean.flavors} />
             </div>
             <div>
               <h3>산지</h3>

--- a/src/app/(detail)/cafes/[id]/page.tsx
+++ b/src/app/(detail)/cafes/[id]/page.tsx
@@ -2,7 +2,7 @@ import { getCafeDetail } from '@/apis/cafeDetail';
 import ChevronLeft from '@/assets/Icon/Chevron_Left.svg';
 import BackButton from '@/components/cafes/[id]/BackButton';
 import BookMarkButton from '@/components/cafes/[id]/BookMarkButton';
-import FlavorList from '@/components/cafes/[id]/FlavorItem';
+// import FlavorList from '@/components/cafes/[id]/FlavorItem';
 import Footer from '@/components/cafes/[id]/Footer';
 import IconWithHashTag from '@/components/cafes/[id]/IconWithHashTag';
 import MapButton from '@/components/cafes/[id]/MapButton';
@@ -90,7 +90,7 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
             </div>
             <div>
               <h3>향미</h3>
-              <FlavorList flavors={coffeeBean.flavors} />
+              {/* <FlavorList flavors={coffeeBean.flavors} /> */}
             </div>
             <div>
               <h3>산지</h3>

--- a/src/app/(withNav)/cafes/page.tsx
+++ b/src/app/(withNav)/cafes/page.tsx
@@ -12,11 +12,11 @@ import { pageContainer } from '@/components/cafes/cafes.css';
 import { useRestoreScroll } from '@/hooks/useRestoreScroll';
 
 export default function Page() {
+  useRestoreScroll('cafes');
+
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [region, setRegion] = useState<Region>(REGIONS.전체);
   const { fetchNextPage, data, hasNextPage } = useInfiniteCafes(region);
-
-  useRestoreScroll('cafes');
 
   const resetRegion = () => {
     setRegion(REGIONS.전체);

--- a/src/app/(withNav)/cafes/page.tsx
+++ b/src/app/(withNav)/cafes/page.tsx
@@ -9,11 +9,14 @@ import { REGIONS } from '@/constants/region';
 import { useInfiniteCafes } from '@/hooks/server/useInfiniteCafes';
 import { IntersectionDetector } from '@/components/common/IntersectionDetector';
 import { pageContainer } from '@/components/cafes/cafes.css';
+import { useRestoreScroll } from '@/hooks/useRestoreScroll';
 
 export default function Page() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [region, setRegion] = useState<Region>(REGIONS.전체);
   const { fetchNextPage, data, hasNextPage } = useInfiniteCafes(region);
+
+  useRestoreScroll('cafes');
 
   const resetRegion = () => {
     setRegion(REGIONS.전체);

--- a/src/components/home/CafeRecommendation/index.tsx
+++ b/src/components/home/CafeRecommendation/index.tsx
@@ -8,6 +8,7 @@ import { useRestoreScroll } from '@/hooks/useRestoreScroll';
 
 export default function CafeRecommendation() {
   useRestoreScroll('home');
+
   const { data: cafeGroups, fetchNextPage, hasNextPage } = useInfiniteCafeRecommendation();
 
   return (

--- a/src/components/home/CafeRecommendation/index.tsx
+++ b/src/components/home/CafeRecommendation/index.tsx
@@ -4,8 +4,10 @@ import RecommendedCafeList from './RecommendedCafeList';
 import { cafeRecommendationItem, CafeRecommendationName } from './CafeRecommendation.css';
 import { useInfiniteCafeRecommendation } from '@/hooks/server/useInfiniteCafeRecommendation';
 import { IntersectionDetector } from '@/components/common/IntersectionDetector';
+import { useRestoreScroll } from '@/hooks/useRestoreScroll';
 
 export default function CafeRecommendation() {
+  useRestoreScroll('home');
   const { data: cafeGroups, fetchNextPage, hasNextPage } = useInfiniteCafeRecommendation();
 
   return (

--- a/src/hooks/useRestoreScroll.ts
+++ b/src/hooks/useRestoreScroll.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+
+export const useRestoreScroll = (key: string | number) => {
+  const scrollRef = useRef<number>();
+
+  useEffect(() => {
+    const traceScroll = (e: Event) => {
+      requestAnimationFrame(() => {
+        const target = e.target as HTMLElement;
+        scrollRef.current = target.scrollTop;
+      });
+    };
+
+    document.getElementById('root')!.addEventListener('scroll', traceScroll);
+
+    return () => {
+      document.getElementById('root')!.removeEventListener('scroll', traceScroll);
+      (function saveScrollPosition() {
+        sessionStorage.setItem(`scroll-${key}`, String(scrollRef.current));
+      })();
+    };
+  }, [key]);
+
+  useEffect(() => {
+    const restoreScrollPosition = () => {
+      const savedScroll = sessionStorage.getItem(`scroll-${key}`);
+
+      if (savedScroll && savedScroll !== 'undefined') {
+        document.getElementById('root')!.scrollTo(0, parseInt(savedScroll, 10));
+      }
+    };
+
+    restoreScrollPosition();
+  }, [key]);
+};


### PR DESCRIPTION
## 시연 영상

https://github.com/user-attachments/assets/1cb7f215-3b2b-433d-bc09-0ebb1d43fead



## 작업 내용

메인 페이지 및 카페 리스트 페이지 스크롤 복원 기능을 구현했습니다.
우선 데드라인을 맞추느라고, 성능을 조금 타협했습니다.
이후에 아래처럼 성능을 개선해볼 수 있을 것 같아요~
- 스크롤 이벤트 리스너를 지우고, 경로 변경 시점에만 스크롤 가져오기

## 연관 이슈

- close #40
