### PR TITLE
상세페이지 디자인 피드백 , 캐러셀 코딩 스타일 피드백 반영

### DIFF
--- a/src/app/(withoutNav)/cafes/[id]/page.css.ts
+++ b/src/app/(withoutNav)/cafes/[id]/page.css.ts
@@ -69,7 +69,7 @@ export const recoCoffeeBeanBox = style({
     ...body1Bold,
   },
 } as ComplexStyleRule);
-export const beanCardTitle = style({ ...etc, whiteSpace: 'nowrap' });
+export const beanCardTitle = style({ ...etc,});
 
 export const divider = style({
   borderTop: 'dashed 0.1rem',

--- a/src/components/cafes/[id]/FlavorItem/FlavorItem.css.ts
+++ b/src/components/cafes/[id]/FlavorItem/FlavorItem.css.ts
@@ -11,6 +11,7 @@ export const flavorList = style({
   marginTop: '0.8rem',
 });
 export const flavorItem = style({
+  ...body1,
   display: 'flex',
   alignItems: 'center',
   whiteSpace:'nowrap',

--- a/src/components/cafes/[id]/MainImageCarousel/MainImageCarousel.css.ts
+++ b/src/components/cafes/[id]/MainImageCarousel/MainImageCarousel.css.ts
@@ -1,21 +1,21 @@
 import { color } from '@/styles/color.css';
 import { style } from '@vanilla-extract/css';
 
-export const MainImageCarouselContainer = style({
+export const mainImageCarouselContainer = style({
   width: '100%',
   overflow: 'hidden',
 });
 
-export const MainImageCarousellList = style({
+export const mainImageCarousellList = style({
   display: 'flex',
 });
 
-export const MainImageCarouselListItem = style({
+export const mainImageCarouselListItem = style({
   flex: '0 0 100%',
   minWidth: 0,
   position: 'relative',
 });
-export const MainImageCarouselCounts = style({
+export const mainImageCarouselCounts = style({
   backgroundColor: color.grayScale.gray500,
   opacity: '80%',
   position: 'absolute',
@@ -23,10 +23,10 @@ export const MainImageCarouselCounts = style({
   bottom: '1.6rem',
   padding:'0.4rem 0.8rem',
 });
-export const MainImageCarouselCurrentNumber = style({
+export const mainImageCarouselCurrentNumber = style({
   color: color.grayScale.gray100,
 });
-export const MainImageCarouselAllNumber = style({
+export const mainImageCarouselAllNumber = style({
   color: color.grayScale.gray400,
 });
 

--- a/src/components/cafes/[id]/MainImageCarousel/index.tsx
+++ b/src/components/cafes/[id]/MainImageCarousel/index.tsx
@@ -2,36 +2,39 @@
 import Image from 'next/image';
 import { useCafeCarousel } from '../hooks/useCafeCarousel';
 import {
-  MainImageCarouselAllNumber,
-  MainImageCarouselContainer,
-  MainImageCarouselCounts,
-  MainImageCarouselCurrentNumber,
-  MainImageCarouselListItem,
-  MainImageCarousellList,
+  mainImageCarouselAllNumber,
+  mainImageCarouselContainer,
+  mainImageCarouselCounts,
+  mainImageCarouselCurrentNumber,
+  mainImageCarouselListItem,
+  mainImageCarousellList,
   titleImg,
 } from './MainImageCarousel.css';
 
 interface MainImageUrl {
   mainImageUrl: string[];
 }
+
 const DEFAULT_CAFE_MAIN_IMAGE = 'https://placehold.co/600x400?text=Cafe1';
+
 export default function MainImageCarousel({ mainImageUrl }: MainImageUrl) {
   const { carouselRef, currentIndex } = useCafeCarousel();
+  
   return (
-    <div ref={carouselRef} className={MainImageCarouselContainer}>
-      <ul className={MainImageCarousellList}>
+    <div ref={carouselRef} className={mainImageCarouselContainer}>
+      <ul className={mainImageCarousellList}>
         {mainImageUrl.map((imageUrl, index) => (
-          <li className={MainImageCarouselListItem} key={index}>
+          <li className={mainImageCarouselListItem} key={index}>
             <Image
-              src={imageUrl ? imageUrl : DEFAULT_CAFE_MAIN_IMAGE}
-              alt={`1번 카페의 이미지`}
+              src={imageUrl || DEFAULT_CAFE_MAIN_IMAGE}
+              alt={`${index} 번의 카페 이미지`}
               width={375}
               height={260}
               className={titleImg}
             />
-            <div className={MainImageCarouselCounts}>
-              <span className={MainImageCarouselCurrentNumber}>{currentIndex + 1}</span>
-              <span className={MainImageCarouselAllNumber}> / {mainImageUrl.length}</span>
+            <div className={mainImageCarouselCounts}>
+              <span className={mainImageCarouselCurrentNumber}>{currentIndex + 1}</span>
+              <span className={mainImageCarouselAllNumber}> / {mainImageUrl.length}</span>
             </div>
           </li>
         ))}

--- a/src/components/cafes/[id]/RoastingBar/RoastingBar.css.ts
+++ b/src/components/cafes/[id]/RoastingBar/RoastingBar.css.ts
@@ -51,6 +51,7 @@ export const roastingStatus = recipe({
     display: 'flex',
     justifyContent: 'space-between',
     color: color.grayScale.gray300,
+    marginTop:'0.4rem'
   },
   variants: {
     roastingLevel: {


### PR DESCRIPTION
## 작업 내용

- 산지 컴포넌트와 향미 컴포넌트 폰트 크기 15px 로 통일 
- 로스팅바 와 텍스트 간격 4px 추가
- 원두 영문 명 여백 넘어갈 시 줄 바꿈
- 메인이미지 렌더링을 삼항연산자->  논리 합 연산자로 수정
- css 변수명 카멜케이스로 수정
- Image alt값 수정

## 연관 이슈

- close #58 
