### PR TITLE
feat: 상세/리스트 SSG를 public/data JSON 직접 읽기로 전환 (#83)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ next-env.d.ts
 
 #claude
 .claude/*
+
+# build:data 디버그용 Notion 원본 덤프 (소비 안 함)
+public/data/cafes-raw.json

--- a/public/data/areas.json
+++ b/public/data/areas.json
@@ -1,0 +1,32 @@
+{
+  "areas": [
+    {
+      "code": "CHUNGMURO_EULJIRO",
+      "displayName": "충무로 / 을지로"
+    },
+    {
+      "code": "SINDANG_YAKSU",
+      "displayName": "신당 / 약수"
+    },
+    {
+      "code": "SICHEONG_GWANGHWAMUN",
+      "displayName": "시청 / 광화문"
+    },
+    {
+      "code": "JONGRO3GA_ANGUK",
+      "displayName": "종로3가 / 안국"
+    },
+    {
+      "code": "HAPJEONG",
+      "displayName": "합정"
+    },
+    {
+      "code": "SINCHON_HONGDAE",
+      "displayName": "신촌 / 홍대"
+    },
+    {
+      "code": "MANGWON",
+      "displayName": "망원"
+    }
+  ]
+}

--- a/public/data/cafes.json
+++ b/public/data/cafes.json
@@ -1,0 +1,1332 @@
+[
+  {
+    "cafeId": "3456e613-742a-8105-a51b-f7ef853d6b45",
+    "name": "트레머 커피웍스",
+    "nearestStation": "홍대입구",
+    "location": "서울 마포구 와우산로29다길 11-1 지1층",
+    "price": 0,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNVzF3tI0t0FkJBkRM5mz4fi2xUIu6Cgv1hZcnp65lZtdcBsfy-l2GR7hQU6rVoJaP2h7cOM8H-xgVtDtYvvI6_zfPGF1Swt_KxRjN9WXLqhHpLG92ACM1fZwrkMxSzgXjOeFfeAZ-J2rHuyQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZM-ZTPDpDcJSnH2EcIqHmo4VRtXynqWw3xcpod_Fu13GhtfmSWWWkcSxMfU4_qICYh51X8Ge3ZLNCAfZIF6z3kV_gRxutL4Cv1PSmXVJxt3n4uWFJjSWRZ8eUSui-rSIKEI79xVBRoHuV_NO--l41NP=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOee56EiVHfBWoTPaMBM8P3_M5UZWXVHP-xZ8_FToIXpG_lMYr3qQR6yj8M8zi5Z5YyasevJ_8LuXsT2qCZN5VL2eed9F3-L3MUsBf0gHEcIj7bDh7U0IhD6IVeCUlPECZptE2mpT243qqn=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPf9X5z6Oj502bkc5-P0FLCjlcKeEZG8T3r1fWXOgTH8psfE38DA5Z_Pk5FVSbym2ty41QpnN9_UauMGwVIpCRkDpP4hnIFjaYI9meS6YcOAR78SK8BRsrBJHd92tGnZ9GCsr7d_BBV-eS1VW7cCRIyrQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNV_v2hUPhslxaNLy2AoeL_KoXda9zvM60dfhWBBR-IlX5QbJWI5Ssk0lceXBcLd-4o5saMYpznrdyrcPRGhitu8Fnt4HEizJvasGtYTz2h8Chktd9zwq8Feniy6soHhSUZNmh7N2v0RgfRiQ=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+        "name": "블루리본"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      },
+      {
+        "id": "c5c030e2-74f2-4031-bbfa-7573231b9121",
+        "name": "에스프레소 맛집"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      }
+    ],
+    "_areaCode": "SINCHON_HONGDAE"
+  },
+  {
+    "cafeId": "3456e613-742a-8106-ba14-cf8ebd0f069c",
+    "name": "피피커피",
+    "nearestStation": "망원",
+    "location": "서울 마포구 동교로 23 1층",
+    "price": 7000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPq6s-zDH5TvI-D_3-Q_-qm_JxmYhOv7mCLVMk4tco4M_H4q1Gsy5P2lk8DhlF_SNuhApKZE5BKMeBtb38juIDDxeonpwPxGZ7vf_JvawXqD_24Um3lVlLUgE87kr7_yUE5p4Me7Q-2kup2BA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZP6Hrxf8Z94w6QnAiyrzqUZzEku7OZS89qVyY995dTRUuEJLFq5CLNQ_mEdf0OyIQPR1_i2ZxbxDrxPC-p2gxcZK17-1cikjSr40BB1s-1Yh8HiGC8hq5-vZf7HKai_bFCN8f9dDkj7MyNFEIpFNqYNDw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOypghhoMRAY9I7dg4pfmWC7yn1iNvofv7_A_XgpNxeTlm3xNEIsnS7b7JE_A8dQBHRG6DhhCxC0wQSXe5wvLd679zJxDqEKnJ99PTVnu3N4BPgO251QuzhFSbDMnDvuh4f4w9jv8wnxOwhYPni5ACl=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNlSpWaR3mdrIdsGXYQZXeb9ID7LmoxoVYUsrfKQ-S9bVrAxybEuVm6g8iAop-h9mJZ62MHuI1i1xDcW3HZpGJGKMocnbkr7aO23WZ-K5qvFX5BMW-VpCBQqkDIaGgRzZ3EDeawR1RuxokBL7aYfUQY=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNrbyWWWHm89uNcUY8UXvHZ_Mmg_ee8htqdspRHOir_BP9Q0kwpfGgrNlTryGDRFYH8N_5Zbw3Aaf3ZryU5sLupc5dLgfel3b4aNh9FKnn9WWwtqmvUYDfb1dxeaa96zlDeqweCLWJ0RHGl3QokMevv=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "1ead9a26-ab24-4d5b-b046-4af8636f6b97",
+        "name": "매니아"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      },
+      {
+        "id": "c5c030e2-74f2-4031-bbfa-7573231b9121",
+        "name": "에스프레소 맛집"
+      }
+    ],
+    "_areaCode": "MANGWON"
+  },
+  {
+    "cafeId": "3456e613-742a-810c-9314-c6c3dca0c7d0",
+    "name": "커넥츠커피 망원",
+    "nearestStation": "망원",
+    "location": "서울 마포구 월드컵로11길 8 105호 커넥츠커피 망원점",
+    "price": 5000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMoDd1eUjM-E7MDr0eLoMPgHxMs83lDUq_dxusWDfbRcOvm2EPMu6poLZ7rC4OvmVhQTuuv7-2XQf9RVssrH5qdr6UbzRNbgJSvUmmto_CcDs81-80qb9uXZDtyqm7Kwh2qD9eEpmPis8fAqA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZObn4lRHpq4As4CytkkUjsZfZLfi1mtJxdNoSX072WlQn71DO9YT1bj53LXEfZVzAoIbrFQaPLbUB-00wVboE9ILpT5rEM2KSuRwgfueZxQsCnmbSzJYi1eRfRYOMbFyy9rtuGhqOt2ZXZe=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNxsjo6A0LBGFAVZadDajBFi7_UCu5bVBXXn5deadsbBBIfQU62lhj-YFDw0t7UjDZJOYBu7w2ySebGTW1JvjOfM6L7bZ0wkJQ5nE_0FXbW56241Qjjis_ekTVcFrUH8-uM8vM5ppYTy8U1euo=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNUt7BQYBX3QM8LOs6ZWbI4UPN2fJrBXXRxlMQvDqStB-lwwzzV1usCvL1AmSVjIwmUuEat68SBIzUw3c6cPeqYWgt-_3aRE358OaNLGjwwU-UDJK0tUaPlPZq_xwsrQuWd-pEE4xGuiSpMkg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNT1I6aAyWSohOYTYCGFw6O81O-35XOlEij1GIlcqAlKM7X4OkD0npBGD0Gt2fe_oiEMM3T5ZMwk8lRYzuocl0MRhjt_mUVa2GKbyR4KKgo2MW79Hxm7fTv2kD39X5Xuirm4N2ol2XC1DrgA7tKAo_Gbw=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+        "name": "블루리본"
+      },
+      {
+        "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+        "name": "대중적인"
+      },
+      {
+        "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+        "name": "라떼 맛집"
+      }
+    ],
+    "_areaCode": "MANGWON"
+  },
+  {
+    "cafeId": "3456e613-742a-810c-acae-d08ae2fbcf73",
+    "name": "커피리브레 파란점",
+    "nearestStation": "홍대입구",
+    "location": "서울 마포구 성미산로29길 17-8 지하1층, 1, 2층",
+    "price": 5000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqE5eHmZGdw7P5_mCUk3g9v8IZy0-e2QYQIOAZ8ovRwjQdCXGol3vPPVem5rwMYQiuWpxk-KWFS0WbGbbswxQX-D1w_FuxjD-Xo=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqESvQ_kpn-BJX1GbZScrqcCRU-zwb96e4yjcwnWBKtnK4CKYIHUYwPahxl2cxFX-Xy_4Z1tt4A-OAjykSO3xfXkPfU22B7PSNQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZP6_eBwyk1tCZ4BbyI-Cqv0TByn7ZwhewfTKNj6KOp7NeRP5ezgJr9ZobHsIPtN9iGMg0hdHHLOOd3hlynxO5uAZhRhJUgYFLCifLVJ5RdzDnS_2qL2dKkbiCw6dtCnO4Pb2CbuVjALcvayDyXnql4hxg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMh5S50lJWPxekDmD1HfHeafj3Y2J2fBxjodCT_FAr_7M0iNkUhxymm9h_Q-mpJadUSI-DPcEgMpmqP3O3wPBEllbFWy-lK-23tAi4azzDwQN04wZn7VnrXRjik4NSkwYEP0dr0KZFl_TWEeyIZ_S9-bQ=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqHLUJ2J6S5laAnPtjMuzLwzWrbqV5n_glNXgvbh1BfBWvwwJQnP736_9pxspTCTNrYu-sBOF_p6I6S_CYPPKTaBbhqBO9aZB0w=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      },
+      {
+        "id": "0bf60d10-7f76-424f-97f3-4450ad284d73",
+        "name": "과일"
+      }
+    ],
+    "_areaCode": "SINCHON_HONGDAE"
+  },
+  {
+    "cafeId": "3456e613-742a-8112-9bcd-d1a2b77758c2",
+    "name": "로투스 로스팅랩",
+    "nearestStation": "신당",
+    "location": "서울 중구 퇴계로83길 30-14 1층 로투스 로스팅랩",
+    "price": 5000,
+    "previewImages": [
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220416_166%2F1650082800337GAMGh_JPEG%2FLOTUS_%25BF%25F8%25C7%25FC%25B5%25F0%25C0%25DA%25C0%25CE01.jpg",
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230825_97%2F16929688374889edAV_JPEG%2FIMG_5918.jpeg",
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240207_182%2F1707297938991FMocE_JPEG%2FIMG_8703.jpeg",
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230829_219%2F1693296774847llUIs_JPEG%2FAE28906D-3AF2-4556-A6BD-1D362DE76685.jpeg"
+    ],
+    "tags": [
+      {
+        "id": "c5c030e2-74f2-4031-bbfa-7573231b9121",
+        "name": "에스프레소 맛집"
+      },
+      {
+        "id": "66002d49-d8f9-4119-99ef-c508ead21371",
+        "name": "KBrC 수상"
+      },
+      {
+        "id": "0921cf45-93af-400b-a9ed-0b85a194f812",
+        "name": "산미"
+      },
+      {
+        "id": "45507d6d-9817-4f8c-a23b-2f119d9101d2",
+        "name": "드립커피"
+      }
+    ],
+    "_areaCode": "SINDANG_YAKSU"
+  },
+  {
+    "cafeId": "3456e613-742a-8117-998a-e76b75241b88",
+    "name": "커피한약방",
+    "nearestStation": "을지로3가",
+    "location": "서울 중구 삼일대로12길 16-6",
+    "price": 0,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNp3w0uyaLAXXoned2nURVQL8iMBiH08O61of7a6sdd6n2vxJjYjH9sJFJtCs2joCfiZbYOeb-k35Rx6nfzCsbpYzvYUeW8v9bWM09q-P8A4NPVdvSmjIQtDbb9jwe1uChdSrbbpCzcb1eF=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPBycmPrMq9l4-8YglHNtXctR3i2PGFCLaZOflzTvyft3h8uLR46bXROaDrfewIaYspiK_xYSigslQK5aebWF3pnwaKwAyFi7eUoMxlFVea7wqdHPJ9tF7PglpQl2f1Eygsb5rtbVEDnnalbA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOgoea073J9ZD6Vu3PBfR6Mf4A_RbDfPi9V6W9uHKA8Irumdm6w-gB2fpZPOlRhu-5Gl268xmNhl2YXypo_AMjgJyLWdRvPCy-SgAgro_aw4Jl7f_SM9wSpbu20x2raAzg94qJoB_Wgq2EXVgpYAdcI=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOSBlb1pkKJsu0AsM__wK9A_rhFYDbx11gjRF_rXZ_gK15vB9DVO6NA-hTyzr16MoU38WgM3sxeioyOn5q0WRRyvpngDqxb6boEnFrSbiYFcyPJdDDrw_ffxZ_s_2cfnfJWlFTqihY2qHvvGQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMXnQH5Pthb-ZpwqjxuBH2hMNZa8bZLHAdHrXTmeDL5WaiaeKY5Xp1KSoJJmj1Gt-l5yMzm5SK3qAbRtUJNYyBhVBpJTIqDV9BPFaL-NrTro9aHkJ5rjPltPGJ3r_2UXjG8zBQwC6xevXaSQJKH7H2k4w=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+        "name": "블루리본"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      },
+      {
+        "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+        "name": "블렌드"
+      }
+    ],
+    "_areaCode": "CHUNGMURO_EULJIRO"
+  },
+  {
+    "cafeId": "3456e613-742a-811c-b069-cda489e0a9dc",
+    "name": "아마츄어작업실 청계점",
+    "nearestStation": "을지로3가",
+    "location": "서울 종로구 청계천로 97-8",
+    "price": 9500,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN9AX14pFZwXCu7y_revxvj42dbrGXbAU1_o1ELnYF2J85R_YeIgiHjWNW8CXdnSwc80ajJikaImOL_Bq_H5-QcN0tMVVb0BUhu1D91SkP8o6vSYopvffM3Wi3Y0rNf7ySeMokdkfAOykfz=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOM74eocZgztWX2MrcFlTiy8k8Nyz8ObTbvVk_iYQauVEyMwqkh2uySa-jEg_PqFcqs3shW8OHJW06djkBir5TMos-9do5j9pVQsWP1-d2CfZaDIdrjMC7zAruNna8A5JDcpCRgZalvc8z0R6o=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPvuZ8PgqOY2Zu_qe3ZvvcUkj7lCewu740Rpj-35BnrAsYzV4hYvwFKjekDPRV-KfuTh2p37cvTLCF0e4LvKkjV4lh9uuwG2-Jn5fQyAqX9Ho2_BAqcr5J4bkamcl0EuT4uENcO9SlHhPyYZqs=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOfyaoz2jjOEsf3_pN7O5VefP9HINEwgsj8D-JF3s0qNnvzBZdTwsXMozdn46_1iHLJKZDt1Krp6_0ObS4c0eCZYuDN-ZghD0MD1YyWOzthkKe2DRvoqYWIfPatmvVor3uPQ_lfjODzRaPV0Q=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMZRWdJMD3D34MjsB6mF6Lc2mWj-9fi1_n2xzWc0BExfLqOyVKcpedeM4ekDYujGjcXAJWdTKc4KAJODYrXaUaLEmgwH59VTfnywIxyWzsJ8NIzoKL2IGbFgjlIoxcS2yNvZuSeuXP1p2OaeAJYi9sx=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "45507d6d-9817-4f8c-a23b-2f119d9101d2",
+        "name": "드립커피"
+      }
+    ],
+    "_areaCode": "JONGRO3GA_ANGUK"
+  },
+  {
+    "cafeId": "3456e613-742a-8121-a957-fc1f5cb28894",
+    "name": "펠트커피 청계천점",
+    "nearestStation": "광화문",
+    "location": "서울 중구 청계천로 14",
+    "price": 4500,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO4N7B2-f52cmt-tYwM42IITAf5LFPG74_8I3Py3HgY9_39QMy-pu9Y8SOGVm47H3q3QvvNnBGYPotci5C3JD534Du-ZCdR80LaAcfGUAY3cutmdWMBwPO_1v1ZZl-fmGeg6AywsTZVJVIG8ys=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPld91bqioQbLsOo3whcGSKES6XLB7WbIgHRH9akpfGCW-SjJNxR1IQG-Uq3falOoMWZe2YCpcR_J3s_oIp_Her97ag4SB4J2dQr7T-fWNeLN5Y4bjZLHFBXOBA2g8w-IVJEY_l8R-Myv873SU=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZORN5DxIgHRx6ZoNamgx_1RLS6vOZRntnSYV0_y5qVbAK53NqzanCDqMXWC1iVGqMCTkVpYj4IPpGBSN3bku7kEqjbSFQixhGKjAwADPdmOLOIspEdTgXMWEpJfzJpaW9Z1lud-DQtwsVNfKvvHZakf1g=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOaQzh1CZMMVikSZspNZCnjJKBgeDk3rtbrwThOHhfHeuz0_HXpGOyYR3zTHQv7IW_Y_n7reeYiWKsJzwEhL7Zl4rIpoZIxn0_3PBpxoOGhMKSWpzYVnJL3-QJbT6mtFHNDwBHlLMWdttGhkg8KFT3XgA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOadGCgWJo1whrR3Uo0Eagq_mCF2RNe3YHRkL3NvDG9AnRHyyg4jm2uQTMfPW9vUJHoCYqFr8HErYPRPzENgOKn0CSf--B4zKnyhuBkcIB9pCU5T_tHwMHWOhuIF1IP6ji2gdga5WZke0ECjObu_kNwhg=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      },
+      {
+        "id": "0921cf45-93af-400b-a9ed-0b85a194f812",
+        "name": "산미"
+      }
+    ],
+    "_areaCode": "SICHEONG_GWANGHWAMUN"
+  },
+  {
+    "cafeId": "3456e613-742a-812e-b998-ecb84f92fe35",
+    "name": "평형",
+    "nearestStation": "망원",
+    "location": "서울 마포구 포은로5길 6 1층",
+    "price": 5000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqEF3B7WteHj1IhJfhJ3g-DM8r4pTmdhoXDdjpjVvb8GNg_7ZxtEN-g3yn7OxFbSknMiSRUijdesImFveGx9uYGjCmLXyx33bRo=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPrfaU3_gLTGnFzziWXmgrDcIu8BlmzEztwVv9coL8TsQ6hQ2sMIAGB_NcQweCWSsyTnN5AMliydmwoh36Tj53shNjMbgSSm2DFZkO7u48GbROcsKYKHHZIZmP5Dj7CCbvQSTOCRHTXzpUFzw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOqrd25Roys3a-iZRn_BV9yMIWd2UzrjRSG8_FYJGL8F-p5K6jAR-v1QFQfDHHkJExH2D87LNpLGk5Gg8gL7-Za3JbKBy17DSIG-bG4I3tl3c_ACg6-yLeEGJYDfPWxvDiVJH96bzj6mU9Q=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOCIZ7ILQ-_YplqzTL0_3885ryBAZnSCeAGIP11w7qWeLKW8Lx-aras1CgSeAMSZpZ6xEr8uwsxNtRFlhbotcgEmdhB91uuofa96VBv7BfbmsDYhI4S8UieHr0_I_ZvzfoW0DgVijjST_96Cw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMMfgLsH-_ZeYAJLQaBku2pEarcyLjOUHV5pwpXDdZLjwn2mJKKXBAZSYZ2rLMRRmqhKFU70ubQdHtsttJSCDCJFF_UL4aGZAEIRFWFcgG3uH3To5hycpaoW-VSgGFhenKcY2WpHPsUs6JQUpY=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+        "name": "대중적인"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      },
+      {
+        "id": "0921cf45-93af-400b-a9ed-0b85a194f812",
+        "name": "산미"
+      },
+      {
+        "id": "d2f64390-f36c-47b2-a787-46227a95ffc9",
+        "name": "고소"
+      }
+    ],
+    "_areaCode": "MANGWON"
+  },
+  {
+    "cafeId": "3456e613-742a-812f-8185-f5e79c36f5e6",
+    "name": "커피스니퍼 서울시청점",
+    "nearestStation": "시청",
+    "location": "서울 중구 세종대로16길 27 남양빌딩 1층 102호",
+    "price": 6800,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqG4Q9pfPVDTyNmQKTb0mLFHLDFSUGFLQUfshfnCA-hOyMJU5a3FNXoCURoydMXYqxfA5CjUHjDfp6R_gxew8xkGCdeWs5j_Yss=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqG2jmzJkoeQLCjoJZwPKL2n-OX8EQBUAZ9l7QVu7IM7iVSE2YygoUT-MKG66jMEdDHeVu-xKuPvguwfoWfOOHREVBNJToDtXeA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNLTq9d0zc6qY6jqfC65BhbQ0CdTz0h5oljFe60Ap4sZGhT7tSD7uMEBdiYIjYFLiPxJHVZQz2pJyrGhop-3JzyaY-hH06OrLXcSNebA2Ml03t6_f52fbt8OrQskux2STY9sIwQcr1G1cpHdG8=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMRo0LRyVmXK7N8DT0Smz2zuxEnIfnm0tBeD4S_TvAiCo1GQO7YzB2zSomttL8zsrbiryUFcfhUon1zagEeO_V0tOyb2FW0YX9INgMMRbvQoqUEeEwurn8WYIeL28VDPsNJnqnK7_jdjsypIQ4=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPy8joCjwbEZB4KHG6rr5KA2MGvbwfo4XEfO4y47ZtZgFcfbwEiHKPmoCL79AjoTG6hm7Py7WBdZoDKhzqwLI72m5ZvJlxCQWwjD5giHjtLpsVi2uFkAzRIByXYjVTYYdeej1bFIaozbyThLES8vjFvxQ=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      },
+      {
+        "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+        "name": "블렌드"
+      },
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+        "name": "라떼 맛집"
+      }
+    ],
+    "_areaCode": "SICHEONG_GWANGHWAMUN"
+  },
+  {
+    "cafeId": "3456e613-742a-8138-9e91-ed9e1a3863fc",
+    "name": "알레그리아 광화문 케이스퀘어시티점",
+    "nearestStation": "광화문",
+    "location": "서울 중구 청계천로 24 1층",
+    "price": 6700,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqEh9OZOx1OceUcsEuQIUuFZc1Ow4oBmgBv0QlV0rLL8V0O-MPVeDYjGKEKHk5cOJnxs4htFl7QdLYPN2IL4slRyOgyOjwWVrEU=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqEL8mbV7G3TsNL8-QCf4MgE1FTURteONLkxCNr8s-W0JdmhsmvmaWV2m6XnKwrdZYRbJr9WCd_ExruHThYX6VQMUvq0jDWgyME=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMOuLvTtB8vSDW4S-uFOXyU8NnW4kAM7ctqdY8mxxIZI5C86PmV-t2F1eFpjLUCwMI6qTg8IcMYQ-3cDAegW36rN_xctZ4nInxRY-GQqhIQ8KAgsIlf8cBt9naAfWra8cRVNVuLjC895FxFJg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMkiQxvhgddG-mkLA3HjqXE3eh9jnwSQFhNZLW2hHOeAo-S9-tcg6tgJHn0_BDHSvuTyCAXUW0PsfJgSk-NhXNIrNrD3F7xTK3rqC-BvHGnE8cx5ITpEaXCeWWEC6ln8j9wC0Ce6fKn174Q3LFl_ihV=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOkZLxXXoTGIioPw_0d7MyyuS-69jVJwSFDIRRZHcN_is-1bR4BdOxiKS7-IBl2mrfT--uDQkokslRftNrzhtg2AO1fpTm6pbV818bi3jSW3Z7dd1ff2xfpG3atCOLtI_1jSfA2a0I_valORVJFyjW0wA=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+        "name": "블렌드"
+      },
+      {
+        "id": "c5c030e2-74f2-4031-bbfa-7573231b9121",
+        "name": "에스프레소 맛집"
+      }
+    ],
+    "_areaCode": "SICHEONG_GWANGHWAMUN"
+  },
+  {
+    "cafeId": "3456e613-742a-8147-8641-e38b38b62205",
+    "name": "프릳츠 원서점",
+    "nearestStation": "안국",
+    "location": "서울 종로구 율곡로 83 아라리오 뮤지엄",
+    "price": 0,
+    "previewImages": [
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240402_172%2F1712037942572gsrLk_JPEG%2F1.jpg",
+      "https://ldb-phinf.pstatic.net/20220922_148/16638262488097T4m6_JPEG/%B5%B5%C8%AD%BA%EA%B7%E7%C0%D7.jpg",
+      "https://ldb-phinf.pstatic.net/20220922_291/1663826177655G8hRr_JPEG/%B6%F3%B6%BC.jpg"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+        "name": "대중적인"
+      },
+      {
+        "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+        "name": "블렌드"
+      },
+      {
+        "id": "0bf60d10-7f76-424f-97f3-4450ad284d73",
+        "name": "과일"
+      }
+    ],
+    "_areaCode": "JONGRO3GA_ANGUK"
+  },
+  {
+    "cafeId": "3456e613-742a-814b-9c2b-e3e9a61d55db",
+    "name": "블루보틀 홍대",
+    "nearestStation": "홍대입구",
+    "location": "서울 마포구 양화로 130 라이즈호텔 1층",
+    "price": 6600,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNvK4UkiWYztGWTEesgXSS1m6xM701GReDczssoBSsX4OuBrpvB5ZauF0OFxJ9aIoqWHEBO0zTyVfZ7rr6azqfElHOyCCC1PChRB_mVy343i2lm6wQsVvuTxmjqrA8LXkAnLDe-dJsmAYfr27kqj81VVA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZObMBjEeGy2NZ1MwpoYsSPlYk_a5n06ILKoZNXMELHm98Z7F0OqvGGahT4-t1PXB-jfH4JGFwGEJF56Ftbm7dz7haf5iiIDiiFb-B44kYRF6UywHiRw8NnLlb47Rr4foY793skMw5IkcducLHg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNUrrV7zJn_0SHc97WoHXFwGb4YNSYWYrFZJ8HuhkTPVzvK8EpRnKyYH9YlMmk60RWKLoZrw-0ry03LUdalxcr_6WeP0U7JY8x26C9KA9mmN5DuT0EsxIwrRy7plpO98qakbAJdSwwICLwJJsM4gw_oIQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPj0E8p3ve6vu6Ddu4yFdwpTXfVbKlJ3W2sBev5yEiM7MK5p1YEFt4YFIsnPcCUsLOhwDLXyeTgV_5Z6K-pYblQSbUD-KlHKLTWA3LDxeKOgJ3epaDOjjr-TZs1P09bS0RgQNTtN16VAtCaRjUCIZAIJw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOKmCcv6lT5ySkuErbc_wt-H84leJctUJErxMu_Xupz6gmidO2rK8qcWNnABTso6nVKu6CCJBpQinn_X6uE4Cys6lbn4KcjziYNKyMMiomYjshzbk3PZFxWIrwVxK6b9Pz_EPRioKnx-t2WAkTHtKZ2yg=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      }
+    ],
+    "_areaCode": "SINCHON_HONGDAE"
+  },
+  {
+    "cafeId": "3456e613-742a-8154-afb6-d508a5bb3d47",
+    "name": "커피리브레 명동성당점",
+    "nearestStation": "을지로3가",
+    "location": "서울 중구 명동길 74 명동성당",
+    "price": 5000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGWpUdkX0HYEVtbM45bFI1nv0xi0tx1RYm56C_04VKwmTYQByWjQCDHFqzrVKSkw5BEQaVGhH1TqMxVQ1Fk1q_z04ZDUIkB-x8=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqH4KKEUdAKWQSpkeZMCCw4X6-t2Poz6qzpaHlE2Zck7Zo5Ndg5jWYXCymaV0eouB_SvRfEAvefDyPF-Bdfvmo-nLVsqmzWxeh8=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqGjsnd6vZ0yJOxYX7hJmN9kbx00jbU69cdA9Dfjgh4PKd7tMbxg7AFIzqoaqT0MQrZQdZvoc3e3J20LlqNWSQfeAKtUT-zKQZ4=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqH1O_vE_KZURRI6vUWhSvLtSXbaI_Kqoy6XuxDj6xuHMAksxTRhjlX_uD_r9xM6zah2jhMC5jkqYMmm_3TgjjA7Hl9pC2JwZIU=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNsg4OrlDxETB1V2DuPGBQromo9bIJlX2cQAht-pMRTSzqKeacYBpYceHU0oRoJQDfVHD9Pt2LsF5b1HTVFCN53AD86VXIK3otbhiCmp8wFTlPxdScpAcZwNQ4RmKGQdTaeKGoKMVVVSwZM-cvK9C63fg=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      },
+      {
+        "id": "0bf60d10-7f76-424f-97f3-4450ad284d73",
+        "name": "과일"
+      }
+    ],
+    "_areaCode": "CHUNGMURO_EULJIRO"
+  },
+  {
+    "cafeId": "3456e613-742a-8158-b139-d5dee62905dd",
+    "name": "인덴트커피룸",
+    "nearestStation": "망원",
+    "location": "서울 마포구 희우정로20길 15 1층",
+    "price": 6000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMr_c7bS_U5cIe8Raiv-ovMROHncOhtuivN5GThAmtPjXazAUpYNFZbg2UaNUw898di99RWdgl3lgio3Z-x8POaBeWCGzrJX6QuG2_vO7bpQl_pzNVSJMe5yriLvwjsEaw7KnASxn14xCIml3s=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMYP7hfZ1gAgyylnzYltkMteSKikTSHGqUMii5q4ZeKpjFFciqLOWPA_-5xO_etX-lqAz47DWc9RjnNVJwvLMwcdovAI32kUhtou1IrFeaEhHhiRiAuv_hGelTnObD1TiQV_uXM3yZ63beLSQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNdtxlbB9ArlnPV1E0-M259mflpuNmIn6h6z-KPjrJKmU6kMilCdbx_DxHMZan1p6QXe7UiMrhH7O9muyVi9MqEZ4A_ONIitymsuTWgil7BBKrN9WA01zYuimyJkZcfluGxmG89BmoEtoLwDkw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOjQ0G0NM3AxSqxdEO0O2kQ9bYdZs8Ofw4rLR-wSqdKOblekj8xSQ5f5udaD6Btm5z3PYLHTqj1cqGQuTW0Od96ZqutsLPHZZj9HNu0bwbYleR1VI608oljy0bOoVKZUyDEjHJPf7yGc3Njew=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPzF7kVEi8nY7C8_4DU-dA5IyFUU8d5hOfDFwMkrHuL-Gprbb2GaG1yBMTDJxyAJ3j7ZGCT4Z1dKXyP_GQN2Smw-XgnAe23xmk0C6IAQ16WfTxpv4-fDUPduRqovFUMXog0crax2FiYQJKcDo4=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+        "name": "블루리본"
+      },
+      {
+        "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+        "name": "블렌드"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      }
+    ],
+    "_areaCode": "MANGWON"
+  },
+  {
+    "cafeId": "3456e613-742a-815b-90d7-ef91d85b98aa",
+    "name": "말릭커피",
+    "nearestStation": "홍대입구",
+    "location": "서울 마포구 와우산로29바길 20 반지층 카페 말릭",
+    "price": 6000,
+    "previewImages": [
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240725_30%2F1721862842184CIHxq_JPEG%2FIMG_5388.jpeg",
+      "http://imagefarm.baemin.com/smartmenuimage/upload/image/2020/11/25/aHSYiyUD7_Oc709NAvoeCxHg5n0XxYBE-_P8HK6vdogKB3PETcPbA82xzKsbC2wm.jpg",
+      "http://imagefarm.baemin.com/smartmenuimage/upload/image/2020/11/25/aHSYiyUD7_Oc709NAvoeC4tLbOF6mOFzLQ8wm-pox_zg0-kViJKMOVLh_Ytmv1xQ.jpg"
+    ],
+    "tags": [
+      {
+        "id": "66002d49-d8f9-4119-99ef-c508ead21371",
+        "name": "KBrC 수상"
+      },
+      {
+        "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+        "name": "라떼 맛집"
+      }
+    ],
+    "_areaCode": "SINCHON_HONGDAE"
+  },
+  {
+    "cafeId": "3456e613-742a-8166-b916-fc0d662dea42",
+    "name": "히트커피로스터스 서교",
+    "nearestStation": "홍대입구",
+    "location": "서울 마포구 동교로 146 관양빌딩 1층 카페",
+    "price": 6500,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPDoub3urTpzKT3Dk-yR6ieyZxVA_MpYc-FXUH2vcrK9r5zvwgL63u0yo9HjBL98HFdNDSZfTLaziMjdiEClbfEbyAurQT9vyluQoh0JtU6-wK596VLu6EDbr9yHGOM0Di2TWnH3WtGoNAQ-mw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPRCd157mKJlYodYRZ9Cc_wJJUlInYIB3GTUnvLBdHhyGZTk1ihr1YU8f_UNQ8lpd7XPRczc6jPKzl6OMmMGcaN5267JnkjYinC8ApLUclSxcRfSob7X7DPYjrbNjo3IQEUUExt-EHpsfwg5IABXu2I=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMqx0NQxv1NkZCqloxLNwO-R2c62mR6O9-fjosyNyV5SCX4t6W8J8dQV9Fgel-iuWDTYEPqMFSnBzrrjdIYmRDzDZMHqyK9ej0HJ7eMwnQmd2Egjixx70AqRHu_IfOA5SDBk8S7S6uDsHnaAFs=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOANf0HCK5vZIpFRBbWgQqTdFFqdzv7o-yEFxQTDvoRbRgQBc9Rukn1_z10yuYdOP0F2fm4Rqp3zaQvPUaQ_WU2jgfwrrX2IF62-xBf1iNs522L9cDQrbXaGwRVo_1BCrb0r1u2k43F1ESO=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOi2q9sHKG1lboZLRmVfBwNxRfoM1ctHXoYva9FWGjn66y4z8OCLmWT3UeY9LGKE4VtQR1HFjevBo6ViY2nnZuICfvv8d0vtJvtVrTDN0E4hhCbm6SGEaiXcc4PFnmrW1GlgP_9jut6dYasTt0X0qUZ=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+        "name": "시그니처"
+      },
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+        "name": "라떼 맛집"
+      }
+    ],
+    "_areaCode": "SINCHON_HONGDAE"
+  },
+  {
+    "cafeId": "3456e613-742a-8167-bbe7-c86d5dccf82f",
+    "name": "로스팅마스터즈 본점",
+    "nearestStation": "홍대입구",
+    "location": "서울 마포구 동교로 129 1층 로스팅마스터즈",
+    "price": 5300,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGyGqDQbJb993TUV-2L7zwgt1aNVW20Xb2gp3-2bwBsLo3frLLaVSJZzKpZu_ZiZrWicVd67KSreXEV-XxYykQWVcm3jxQ0_n0=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPcre4CW2XpB23Zxma2YyoIaPiPU813B6y30cwiI8S5DM43mA7awR_Fm96yuIC1LcQ1TgRCi3IEfuJxDCW8PaNYAdAqcIJ6oZJgKT6zk-inX-Av0UwUv6XvFOZEVUt4APjvz6h_l2t4GIGxBw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMP5KQLXHrOXCZ85YhngPrR67kql0GCe0qrvS5qowNbH3fSqpRLjF6OsY6IxOf3jFGNmi9ztkYbqNDK6qEb-QxNxFAHD2pFxWQEzCG8LqJaP9oOXRQxzSB0ojxO5ZNw30IFE_6WKPejM4SjuPp-oOIZnw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMpfhUfx6GQgwsNRiKbb6jxUe53eOg5FXhXbHBzMQb9cD_YFqYIzylFgbkJQIm6aOckW2Zl12WcKl5C9w8lQoe-UR4VOpHPVYT3xxos5DopF0actavo56WPOpYbqrHYULECyMI6_zeTUWyWuA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMGsewDGTUmdzJBYsC2Tu0S2cIxgGN4wYwZFAbj3CIU6VJRuP8g9u0k4foKdqJbHck5tqcG94B4R3pHcUGFXkDLo33S5O-M4aOUhjegYiZ3uT2b_hdlzjLN0rz3C4yvJ2i9KbbOyw5n4zyGEeA=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "e36cc3de-cfad-4eee-91b9-eb3d2c421113",
+        "name": "초콜릿"
+      }
+    ],
+    "_areaCode": "SINCHON_HONGDAE"
+  },
+  {
+    "cafeId": "3456e613-742a-8168-a4f1-cc45f6b820d2",
+    "name": "헤베커피",
+    "nearestStation": "충무로",
+    "location": "서울 중구 필동로 32 낙원빌딩 1층",
+    "price": 6000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNXconVpn4gyBNZ_PVV2ZrXWvl6vPqE8EDA3c99o9NQfvD6CziB6xznE2VgHCnfhp95ezCYUX4D8Z-Yhx_iA9Vi9Z0onZ3IbuRj03ae0nhHz8Lvhfmp5ISJdD4nA-0Jgu9ryzh6LjQV5o9rQg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNme6-UVxvVe3l_ZXtuNIkNP5Sqhtz2zfNM8HIi7kYZVHe8onwGYQk-Aaw_J_PzenvR88K2PZEWnW05etj54Aipj0wpSOWcvPx_POnxj_6sHOXO3c0hIxi9qiFNJQ_7CqcsxhpHRMufZqcfnAQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOvN4VJTYoc3zIu84iBADkmme3STzVqTeJmKAE6Q48YYira3xzd0JjBOvBzLEiN3K2AQQeHbO9kkzvKN4z1RtHynGTXMfW70D6LABRgIULoXnAWxmuDZTQJuy3n6BN_tUnqJkkhuFvJvbAx=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPzLlEdWiqdt0aAhGOXDScX_LHSXPFmP-B4FnQI6JJTKq9FX0eEik7iOq3ODLsqHSz8LppMDdKy6ddu_SptQKKY6Dv17-0n2G5HxEgckbCvgo_amyRaL8rV57gEOGQN7-6spKFl69qLZxvR1_s=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMr1AROEx-x5kiRL3mwuuGlM38pTWkmlkD3-ZajvNGbV5i4BodoF3qrVSPKP4ImpH0cHhcJwpA1PqF0BGQtLILUymYNlZzsuN0Im8J6ss_SaCIfSro5QigcZ7JX5fTye2mi5avdVMVcvBRsoos=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "66002d49-d8f9-4119-99ef-c508ead21371",
+        "name": "KBrC 수상"
+      },
+      {
+        "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+        "name": "블루리본"
+      },
+      {
+        "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+        "name": "대중적인"
+      },
+      {
+        "id": "d2f64390-f36c-47b2-a787-46227a95ffc9",
+        "name": "고소"
+      }
+    ],
+    "_areaCode": "CHUNGMURO_EULJIRO"
+  },
+  {
+    "cafeId": "3456e613-742a-8169-99e7-f8434bb3c01d",
+    "name": "플레이백",
+    "nearestStation": "충무로",
+    "location": "서울 중구 퇴계로48길 32 1층",
+    "price": 0,
+    "previewImages": [],
+    "tags": [
+      {
+        "id": "1ead9a26-ab24-4d5b-b046-4af8636f6b97",
+        "name": "매니아"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      },
+      {
+        "id": "0921cf45-93af-400b-a9ed-0b85a194f812",
+        "name": "산미"
+      }
+    ],
+    "_areaCode": "CHUNGMURO_EULJIRO"
+  },
+  {
+    "cafeId": "3456e613-742a-816b-901c-e41c2416734d",
+    "name": "퀜치커피",
+    "nearestStation": "망원",
+    "location": "서울 마포구 동교로12안길 9 . 1층",
+    "price": 5000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqFPQuvDl30fQfYvO9k2QZUoroD9KYzrlZ3YUo22BGWleoVGH5z7H_9QWG8GLEGh_R_IMmwrv7us1vInVlWyctUP-kW4Vz_-fpQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPrj1t5x7XsGho3kmxvb5xWOXEd3eNi87CCYYMbECpCF0HgHhMzsp4P5IjcV11ikaTnpqD4QBp6BimQFTMfvzS3Yt7GUX-6sIVAfU4zyBQfHtAUUEJesmPPuHKsuvdnanG6wAYmdJ9PgKEEoCk=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPmAYPSZjqnPxUUQ2fnt80eRejHFfMmEYfuW0Bfj2ef8toOLfSX7KyFj1zdrwOVSzzoN7_QlYSxFhJ_eN7nBUmqXIUaJYTzxJNYOdDeeBQwYTFevpSTFLffPwAR6uVNglqZsXKNhfLtAK0b99C9jyu6=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMsvxU8XXA2dy-5jsxZmC0b6eRbCDRpECF4dZt1Y0_n167LMn-F_dEKosIWLciBwZJ4KRjmkFBEiyx602S10VSmYQzIsPZMW2CoFNYuLg4OQNnmqmL_ntDUauOBs9OFTQhddy6eWSOkCEkxhinlgNxl=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZONelOZtwJSyTAcjsX8ZZUJNZq4CSIXQ2lY0czjC1UwPbQ4pB4zTjhKlUERMhU5Vpkgu064qo-jKwA7rvjxSfsUMxVrzvVUUxQG3v5aSAIq3mbEZKJoTxfekjz-VeQZIsb1nI0wKIxy5hi7EqkKVIFjnA=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+        "name": "라떼 맛집"
+      },
+      {
+        "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+        "name": "대중적인"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      }
+    ],
+    "_areaCode": "MANGWON"
+  },
+  {
+    "cafeId": "3456e613-742a-8170-962e-d3f534d87546",
+    "name": "펠트커피 광화문점",
+    "nearestStation": "광화문",
+    "location": "서울 종로구 종로3길 17 B2층",
+    "price": 4500,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZM4TiaZ1Up8pWG1c2N83yN1ilG6kC-cA6JrnswqIkkkt4DmisQgfeHBTZgctXhJ6ki-d8MPy5nWM07GQ8c9kzdCrhN2g85EHgmg85USaNa1b_kdN3-3yykEVvopKfIbSONlzCA8SjdacSMSA7uwhqNRKA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNFmYbH8g34XQ_4cd9zgM52akohI8f-LwcbRrSX51ZlrazExSDkEMxDBtYlXs46u9fqwUngqNLs3ETFP4IDNfGyZQtVC5I-a3uvA9hLoQjwuoVEZNivRIedOjFO_Hi86La0UZSGTNxaKwSqJ4jqe4yw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMiUaKO6272CGUhyu7vT2RzLPkI9i9Pau6CWR-bzWKI6bM_I0Uu9uExCGY-qxOrUYceIVOFrBedyXzrLf-11c2OX2fS7wCZOHPRvVhUS9b14dObG4WL0YaBhMc2WlzMEGvLAd6K6KXbnvwvDJFRyHG5qg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN5IimTpoS4-LmRk2BNvj8OZ3JxD3kyisBHY1Qqnou-Q7KvdNv3yYTJciPX9bwF9A_ti9OmS8LPMomValDDqLVMMfHC9j-7nq7RKj-CVIxs38piyJwXC83P3l-VTh8MIsOL9eNVWmB3cZlY8W_6Biw7=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPS9MHkzyV_MCVvHrIU8paKhx5_QD0dxO_1QOnR7yFLHlgGujcTJkC8NKf3v9sUcqwZXv_FJAWrRMeWUlpsELJxvUO9XIqXxsekVsst1gvGAUkFSh-0UfLAM26yhkpNtoUK8F-rwXlV1PIB=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      },
+      {
+        "id": "0921cf45-93af-400b-a9ed-0b85a194f812",
+        "name": "산미"
+      }
+    ],
+    "_areaCode": "SICHEONG_GWANGHWAMUN"
+  },
+  {
+    "cafeId": "3456e613-742a-817c-b986-dcc0c7945e00",
+    "name": "테라로사 국립현대미술관서울점",
+    "nearestStation": "안국",
+    "location": "서울 종로구 삼청로 30 국립현대미술관 서울관 1층",
+    "price": 0,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOb0J7etstQ0AZL71MxwWcwFl2lEo08E1DkNxgfHTtu_Zw4vocVXtPA-aqLhXACDxDNUUxUFcMI9XwyLOBBaifeWXtruOw-olKbNGSHf8JS7Q4JV4UMBN9evuhNKCzGA5ezgVV1vBUTarBBgcaqGH09mA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOXIvEucNdajb6r2l5pX6g_3rvuEDRQD8ST2KgkC_VJ-wN7xEqo51NnQZ7Zcy-7VnKoIHvmuVO1I1Pd3FqLldKlWOOqIrg7V-UGW5CIWW2Qo0lygNkrdves3Km80H6SPK0k1m_aVJ2Gs6eF0vdmnkWUIA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPnPmjw6KD2c9CM7FEfQU7ES_DOqFM1Eqp2ClN-LVbY0MM3K27Lw-u4oZFOwEERXtOXRD7hurSNs8qdS4bo9BXb5lHwq4laOL6NUcwQDDPZKTzUbhGr9yc2RvVzhxo-IWMHlR1waMTzHEkxBtaC9K6g=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOA9lN6Unq_2cQgTombLhZDUjBWEjz0KHD4h_bQLqxL8Td8PNSqeCVGTfl4aQJU6fbyw4SBmF2b2QWjNt3X-eAjX02WgxXTxYfXZXbdDMrsHTgBzuvqLOfAkfZykqD7GbdL_Lp-NKIyqWhGQw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOgb4u3Oi4ENeiLnWLZm-aTIRTJ8cLLyPlLiKBG6D2ng4garBv_8_k8e4jhVFUmDebCywlZ_kNY2xJsXK5t5jIxqDsvuvFgsUveOwBSimv4e8QW2qSyS7P0kkThp5i8dxesRtQ4mry2ku7V1-4QAeA_Ag=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      }
+    ],
+    "_areaCode": "JONGRO3GA_ANGUK"
+  },
+  {
+    "cafeId": "3456e613-742a-8182-960e-e41c0092839c",
+    "name": "빈브라더스 합정",
+    "nearestStation": "합정",
+    "location": "서울 마포구 토정로 35-1",
+    "price": 7000,
+    "previewImages": [
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230531_262%2F1685542994202MxNal_JPEG%2F%25B3%25BB%25BA%25CE01.jpg",
+      "https://ldb-phinf.pstatic.net/20230531_101/1685524957088kaOdb_JPEG/%B5%E5%B8%B3%C4%BF%C7%C7_ICED.jpg",
+      "https://ldb-phinf.pstatic.net/20250212_55/1739343932180Fhq3V_JPEG/DSCF3637.jpg"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+        "name": "블렌드"
+      },
+      {
+        "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+        "name": "시그니처"
+      },
+      {
+        "id": "45507d6d-9817-4f8c-a23b-2f119d9101d2",
+        "name": "드립커피"
+      }
+    ],
+    "_areaCode": "HAPJEONG"
+  },
+  {
+    "cafeId": "3456e613-742a-8184-94c5-f50be5356e64",
+    "name": "망원 지튼",
+    "nearestStation": "망원",
+    "location": "서울 마포구 망원로 73 2층 ZTTN",
+    "price": 6000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqHU69RXln7bbG3wQTiv9jHFLjaPq-oCH5G2g4Pup7KWOqDQgqb4_H5h_VBhE11ECYe4tIB1FAFVkFj-XaDG4R3IIFfMSnQRFak=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqERLMLwPTrWhAOw8rKQ2ySKLRM3IU-Laa4chG_neePs-W6H-T_9BDpOgYZLSI1oU9zpNOK4ap5G5038ZMIeeC3D5I34aUgiBNE=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNttYFN7tEYN6o36EGxODk3HQYXWOMKwbKUIh9CZasyIO4iultBqdfWMQQeblS3FIBvwEiaSzY2vkUdupAOGZqlaW1BeyQz67Vyu67ScXQTCTZLggGhndNFARfttjjSxR0sKqmWs0cqtwF73Zs=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPjxZ7QTV5rhvAaJn8Jnj9UFb0C0hgA-jMqPhnkyevI4PGhmE1o7js4AbCawPQJb85rXLl6KNpJgaFeeRgzbnk8vW1TDW9QsdQrLUTDyS-TKjepV_7q59_ys0EINmeS7Cz5CyyRNa9hNpNrNPGhYwPWHQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNEMkdD_--w_Kr5ldW0aCayXgIqCpwzxHjT6aXCxB_Gi-bdJivW94NgrkYkRsmSY39rz2Cq_MoKQ7UX3N3OvmpnGVz8B6-3d3zoL3fVvKyhZwLQOZrxxMnPd4F1OPJe2avs4HIrJHBmkgMYogkroTG8gQ=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+        "name": "대중적인"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      },
+      {
+        "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+        "name": "시그니처"
+      }
+    ],
+    "_areaCode": "MANGWON"
+  },
+  {
+    "cafeId": "3456e613-742a-8189-b998-eaeabad432e2",
+    "name": "커피리브레 연남점",
+    "nearestStation": "홍대입구",
+    "location": "서울 마포구 성미산로32길 20-5",
+    "price": 5000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGMMEHOipREJd-v-hrxQf0O99vcnnlsoiBChHLi2aMApVzPZf-GR_QZu7Gp6lg7g151J7BOo--BaPfmIMvIQXW_ver_VG60SbM=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqHxaT1RrmZ-Xh0PEjsawZTcZTsirw5kZHARgqm7ZxshiQrBl5tOLKsI6DQmrBaRY4uY4SD-YI9x74u-NPnh602lOrXaOyNCFx8=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqFzsMNE4Ls5czIiYf8lcTQwFFmSwjmskeNWHXPLsxXJVfg8Xw5Lglbr4iLWSuE22FgimLlKnTNlbB5yWYmgq9WQdkZCreufNUo=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOuVSXU5UfIwB0rhTA_oTs_mz00FmcDoitlYDg4qSAvR8mzoqeR76YXyJ-r-S8DsA-xhwvSfP0Bhw5LCCdfoVT57YntMxU5EsxgWbhorNlP_ohN70AIogdVmGNhg7DCswg1k50K6odYs6mxkAk=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNYZPn95Sn4ESg6nJvHwnQ-LoJTMLsFp2VLB4TxZEX4ZPUIqv9fzmbuCjl60tTw0C7dQ1ehjqo1lrYKnL-k9uwgpeUUEGTwlG7HVqGuNX2Qwj1wkdZVU_YJ4QTbZ9P_9x5dVY1WsxWWqmu2ezY=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      },
+      {
+        "id": "0bf60d10-7f76-424f-97f3-4450ad284d73",
+        "name": "과일"
+      }
+    ],
+    "_areaCode": "SINCHON_HONGDAE"
+  },
+  {
+    "cafeId": "3456e613-742a-818e-a791-ec118760640d",
+    "name": "리사르커피 종로점",
+    "nearestStation": "광화문",
+    "location": "서울 종로구 종로5길 7 1층",
+    "price": 1500,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZM5RvPTtATC0dwVeDWV4jZYhfeiyu4EwCVqNTIycTZLU04_vxi4i1OzN5zfgD6NdHMC3Uy6IZ47bh6qecY_4Vz8hO15I9w8rlZb-itnbhDcZt2CuLbXY80klpuMLOQy7GWfDd0MWk6dYPNwEuQ=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqHCa6Mh8Vm6_RjLHCUcDiQTyq0q5brjgAQhNKeLxGTqOBHY-n1vcTSAR2zr7IU8wticE9Hy8lEpTIsya7m1C0TVzBzdEXVFCdg=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqEfPZ012Icw0rhMQ4YDnqq0fEKBoVrouNgcryDL05mpKrPz9ztYWmxQGsZzHOKH_vVCbOkOQkEBSZdo2Xwjaavl73OVuP7FGac=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqF2j9nCf0DKr-6DNHRUf4F6XwYbo9Tla0UigX-0zSc6D4QDE-pWiEwCE9iETjqXodL-NPCA45tkubZJgI2k2PK-7mWNOJnJ1r4=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqEql8vs9tN5A-Xgnnz9eGR2oESQ5UrJlOpJ8wbR1U9qhVj1axTknYkuP0_cb6tD5Xsf8AtJRw53bbdwyhZHahBz0cIc3U_MuTE=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+        "name": "블렌드"
+      },
+      {
+        "id": "c5c030e2-74f2-4031-bbfa-7573231b9121",
+        "name": "에스프레소 맛집"
+      }
+    ],
+    "_areaCode": "JONGRO3GA_ANGUK"
+  },
+  {
+    "cafeId": "3456e613-742a-8192-aec1-d19b274b78b9",
+    "name": "텐스퀘어 남산",
+    "nearestStation": "회현",
+    "location": "서울 중구 소월로 33 1층",
+    "price": 0,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqEy68BzN32eUUyD2vQ2YKiTuc8bA-9ARBt-j6UV6e3JAfnxSV8-jfPyIRBomNOC0xZfKxUkpz9u8iWbVk9177uA-DxKpXuVWkI=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqHZvJmgptZyF6QgHu9zDW0Ry3DNL5SoGUYxTnx_hLYIeNFkb2JP2esJJLMXlMxjYUIMURv6FMfiod6MFMy6Ob3Jg02bYfTcyGI=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZM6vPR5kq5r5mifvRl0APr5OPOVryL-FeLXtqMaBfwSZnUyAypiiQsvsQAUaLt2OF7AmDpBpt3aUmElEzoH4xZtQIW5kBIPW-8fdEBMvYam_n79LR_HPbhWJGS0NLq-Sg3t6VDMANaFEwZC=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMaeYOdZORelo4aK6k7qrsueeA7s7AzQOZvst2w4Fb2UP-tST1bT-NLpyMKYByxCPbIUpA7QuaakcrD8LEl34bGPqbkTA3pMHdXZ588_S0-dXvh_BGVC19X8fMxM9mj2oVnj8XUscM7OtenbruOZ5FhMA=s4800-w757",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPU2hvpcoeOcBDT2Dn-CWi9EIGpev3OKu1qd9WtpoaVGaN8r9rG9arvCFPBpd9rxYhETY7FlXGGY1dSAiu5rUPAOTTjE1csL1H_dDyRtz139tI6Fc0Ysdo8iIquuiXVXeBtniC280oWjw92MnoPDYaU=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "1ead9a26-ab24-4d5b-b046-4af8636f6b97",
+        "name": "매니아"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      }
+    ],
+    "_areaCode": "SICHEONG_GWANGHWAMUN"
+  },
+  {
+    "cafeId": "3456e613-742a-8198-bb10-d841006daf57",
+    "name": "노띵커피 본점",
+    "nearestStation": "동대입구",
+    "location": "서울 중구 서소문로 89-20 1동 1층 103호",
+    "price": 3500,
+    "previewImages": [],
+    "tags": [
+      {
+        "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+        "name": "블루리본"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      }
+    ],
+    "_areaCode": "SICHEONG_GWANGHWAMUN"
+  },
+  {
+    "cafeId": "3456e613-742a-819b-93ff-c4e48531760e",
+    "name": "섹터커피로스터스 본점",
+    "nearestStation": "충무로",
+    "location": "서울 중구 퇴계로36길 35 1층 섹터 커피 로스터스 본점",
+    "price": 4000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOe7IBy25Y9LS2R6ecttPbvDAXIz9mN9gErwTqCnPQAfiIjXklqMcYLUtMDhIPHRNLv1oqTQLLxSDHJRWPzLnKUUFRFym1v25s6Ew0TyP-8tfhfYgI9Cooapws00ph0zGooCjDrake_uV1v=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPYFSGswk1-tkTDeP2HaWqmsPBS3fPbPGBDO-i6vr1C90Z0cyjh-DgEACNaVEhl18DF33Z8OrrahWUVLZSMXpU8bgjpNe6gJnj3JbH8DO3kqF2Ed5sAcl9PrDzJFd6q57f_ICu7f1skN-iJ6r4=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNWQakFtptCyAeFQtyNWRK_yXP--5PZO3SwNv8YyZF8QFF7b9JtPeFa3SIYsHy8xl5P9gZQkoqZVam61usNM_pdviy003xxvo0NYu8lIbFbM-Gto5dH4NpcrwpayzR5xzi8wXBBDQBVe4cq=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZM72A_f4pbn0ugcDmqeplryyok0CFRJs5aPTge8lB0FU3rUv55ZdXDDlwzBP8SDD51oWUrQW-NjW-mtOoYUkmPYMFwHVcUzcx0bK5HPQYgEn65dJJDiwspdCZEB1X0gqknZktBjkkvjWO0l2w=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOwmK3A_AICyXSE7JSldE3gDn07WvkaJjMLP9HqOQUKUBHbBZwcFbrShDNtyMXTn8YTXELRwYoSqMLaDl20XBb6HhnpVSszVDTzdzT2Oyg9-IwU1r0D2-w0DUkEcL_nN4qbvCIjJsM3hAVyuvWcZPd9_g=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+        "name": "대중적인"
+      },
+      {
+        "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+        "name": "라떼 맛집"
+      }
+    ],
+    "_areaCode": "CHUNGMURO_EULJIRO"
+  },
+  {
+    "cafeId": "3456e613-742a-819d-87b0-cb05eaed1ce5",
+    "name": "블루보틀 광화문 카페",
+    "nearestStation": "광화문",
+    "location": "서울 종로구 청계천로 11 1층",
+    "price": 6600,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMu4EcMAUPJv9kNTxt3k9VPcE3xw9YhfaQJJMlNI6T1bQC0WM7Ie6MOXObEMono6gGWg2s36en44SbSY8WNiaN0pldW7LKcIPpArGX8RcQJmRjgV0uaFPOxU1EM8s0DWiNLR6NwbHpyVeKLysM=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNYTDonMBKgk9EhCIqg19484Ng2yFlSsWyO6WKPmRUyE2wZzTE5AGUOyjwR7QusMvjupbeWrLz8vnM7fhbwOU43F0fWJoNH2VInDtenEajIJb3__YmPtsTXkng3hjHxvMofvKwcmJWY4MMJiHk=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOyRMlQ2BOkOajTVlvwbDi1xByol_tmHR8X8DsvIYlekrVka0gy9C82foI5gDUF0ivBU7Usou-ugrJyJXI-uj5ZKSfflb0snP5o3PjJIW2Zd_wvWmTRRdqRQtiruH1bnIzvjlqLCUk8KsgK-Xl2RpFbng=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNupoUThCrek1s2NYGA3qknWsKwBOfRmuyrS8E1oxy3BULv4Uq4MlQTlL6BmweU6FroDqiVoqSGcP9HlPen_aXlJ7USCPkNhSonVAKlFCMXYTIHqUCbB_6C1pGP2GloZMRqS7tpNMdybUYwv-Dwl4Px=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMc4tHyRC-wYGi8K_QThb6TI77mHmkdeisI2KVCC7Sxb1hr2NVCtMKXDHcJkSr2hrkbIC6tIHop_08uyO2LXTrsSJAc54lxma0ZjlYI5tOX3cdO71B9h4bYE1tM-ATtft741QCzECqIGS7mI9c=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      }
+    ],
+    "_areaCode": "SICHEONG_GWANGHWAMUN"
+  },
+  {
+    "cafeId": "3456e613-742a-81a4-a35a-cfc0bd4c8aec",
+    "name": "커피그래",
+    "nearestStation": "약수",
+    "location": "서울 중구 동호로 204 1층",
+    "price": 0,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO-KO_p-yiiYdw4fXxXp9MR3Fu_nSvQNv6vr2wFyKisy8ct_ZFGuTvp_HFuCruSVwC37c69hh5Zt7tvDDp6XNZmdDcYM0hffXFmfemktjELbF4uo5uCPZKo0_ngtBJGRHPM8Xg3CN13V8omPNY=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPsz10dcdsVBcsxbPp3r-McVVu8lu_tilOM--98tL-V9iu5r9OCzdpoDALejW1ztYq2ZnsUXo1eZcrjymdfvF1Y9pQyOpb6wAXOSbEll9pVV0WxLDF3IRrfwEPYqEPKLpCuoOXPeMXVQ8Wb=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPowr82IVExNest0bz9vqAkkuMMsPYRtqj8AOhitvpdOcFbCYBdYnRN8U_ByS5wfkX4jj-91yZeiyTdWCV0ufJ8o0YOY3LMJxcDqY337VnafnGq__jFWwgyBu6bdpT4htAMDK-Qf9y-Xj5fg5o=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNnvFyRVE4T2Dn8WRaiOXDvm12yhCT52QIdasF1GjY2B9oLvp4_muMGEgwN1mH4Hg6abayMcBzfJtp2rfWTEAuE5BUgTgqtFNuhiUhMdwXZxTfQS_2lma6yMlKrJkHVRGm8_Tzn2Jo2OOF63Wo=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNY0HcVqxZgoCdcXq3f95mjZa6oL7n6JyuRyon5PUHIPnLpXCxBt_p91K7-_fpqdf5STFKkRw3BEWznrQE5kxR7owLpuXECNL3Pi25KNMNhBUmJ7R9P6gFnnUb1DpGzYSU474OC5MXSOy-J=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+        "name": "블루리본"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      },
+      {
+        "id": "a43f33e2-31f1-47dd-b479-2b60e7d50c26",
+        "name": "꽃향기"
+      }
+    ],
+    "_areaCode": "SINDANG_YAKSU"
+  },
+  {
+    "cafeId": "3456e613-742a-81aa-870b-e8492d89a078",
+    "name": "루틸",
+    "nearestStation": "망원",
+    "location": "서울 마포구 포은로 136 1층 루틸",
+    "price": 5000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMcOxLjdPHPLcUHBAnpOzLQYTUvnHK2JV5yZw9TqvX0Qrj1oeDCk6YOZsrG_7DukG6dGB9paKWrpWrKXkZ4JUc75cmGAmF0RlXKCNhLgjB7r9WkRjS8c_qtMMAT3GxhuW6YEWJJf2BSDsnGgtXy7jQs=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqHA83D8XptyZBxXOMfU9EEffBdVJiZhnzfk84Ai_6nYtLC5d5JMfo-FJ-WBfQRwAN3XI5j-ESYu_T_YmbkOqlvdEynSII3_Asw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOV2s0dbvzfVH3da9YPSbFagOAIYUUJRn1-as7oBkK8uOgCJKq4S7-8xwGjwf8_yOkZ_DsrmJRlp-OiibpXqEExEcHzSsidpayUsfEMPnnQyO7C1JrpzM4qD2aFST2wDi5PhbA4FXeyAvpvom9Mn9tzuQ=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqGjeWxFKPpNiB-GBR3dbR4NNMVTm5TUIyHd4NSoKe3bnXbtJ4-3LjrrRW2AuW7S1HMO_0i_42u8J98lRDMTwllhzihedxYuDco=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqFamAft6fUWCgVEz0Hevujb6al6zFSy5Zjvjp0LdF3xFcmmOuNp-_l_Cw3igEbxAVEBaWOFG8v-X-k5Os5g6ogt0lwco6GfhXA=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "1ead9a26-ab24-4d5b-b046-4af8636f6b97",
+        "name": "매니아"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      }
+    ],
+    "_areaCode": "MANGWON"
+  },
+  {
+    "cafeId": "3456e613-742a-81ac-99c2-d659d9f5c674",
+    "name": "결",
+    "nearestStation": "광화문",
+    "location": "서울 종로구 공평동 17",
+    "price": 0,
+    "previewImages": [
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20231211_85%2F1702260626377lmDSt_JPEG%2F%25B0%25E1_1.jpg",
+      "https://ldb-phinf.pstatic.net/20230531_283/1685525917846LOV6w_JPEG/%B5%E5%B8%B3%C4%BF%C7%C7_ICED_%281%29.jpg",
+      "https://ldb-phinf.pstatic.net/20230531_242/1685526003844vkJ34_JPEG/%B6%F3%B6%BC%B9%D9%B4%D2%B6%F3_ICED.jpg"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      },
+      {
+        "id": "0bf60d10-7f76-424f-97f3-4450ad284d73",
+        "name": "과일"
+      }
+    ],
+    "_areaCode": "SICHEONG_GWANGHWAMUN"
+  },
+  {
+    "cafeId": "3456e613-742a-81b3-a1ba-c4fdfeb25956",
+    "name": "벌새",
+    "nearestStation": "광화문",
+    "location": "서울 종로구 새문안로3길 12 신문로빌딩 지하 1층 22,23호",
+    "price": 6500,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGdqlkD2as_qw73O_SeO84iAxT_A6Xr03On7UiWjssW35N1Jio0j-UoocPSKPwI1WyHJlfLWU3RyVkyb6yH4Ybb5keVGXc2uEU=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqE2JRBcs_oZJdxWjTsYUh9BmGibXWw07SBomxQaDTIp1kGn8BwGgC6lF14tk0zCestE4DxTY7D9RviVWX0VBp_hp4nO4Bt-dNE=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMsW-1F9aIagLxrJ6BQZ0rQ1d5_nx3SmAco99fihHjGKFxQgx5Yai_iURsAooW22c8BWNsxaxXr6PxHrhmUg1X_m8F5atTwVfOyXmJWFr0XIhRLQNsh228pr_PZOhB8vzErQDiv59CgI7eE7_A=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNroX-rKwbOKCL0B5SfiVPYOiWnRS00aRHe7-r8Hsq-sYbtk1p23IGDvwS4SA5IlSpjyiWJZZpC1LOaG-P5vDZ_8WWGanW-EN4r2PAqecfwcjRe8LC4TSOKrxbdqFCHYwLU2u6RSAJpdMyKknCtYagdkQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMjIUpEHoAc6KQKyEC-BWJmVSsFE2DHGb2v7KRCDWwacgg9DKZSogDzfdXG7pRXOWmfMEwP6pdMED-2A5HTTRcz8j8na-pFiIzAbY6-eekoAd257PstIY0rR9AcnvPdm89y5r0_re64JyYznyJrEPk4=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "1ead9a26-ab24-4d5b-b046-4af8636f6b97",
+        "name": "매니아"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      }
+    ],
+    "_areaCode": "SICHEONG_GWANGHWAMUN"
+  },
+  {
+    "cafeId": "3456e613-742a-81b4-903d-ea20420b9a3f",
+    "name": "커피친구",
+    "nearestStation": "종각",
+    "location": "서울 종로구 삼봉로 81 두산위브파빌리온",
+    "price": 6000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN62RQ1FnwvGKUmwr2fz9oqNtG5yj66k2NZPOdDAfxP3dr1j2xdu5liLLeGrienmwhFgRoKNbE9YMKCVFJagsN-12bdWsGIZjc96rL-UtLkgbWD1XSds3DArBnFPi0HEFpKJqnb4wCYh8qji9k=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN1jnggu9Zs0fJae8gEG30J3Nepv4z0lQq7yD18iKLkFfbjyE5DZX8Xc6KCj4vYnMMtzoYbCiOyuP3ARJIHYjEKu4fkI0N-rItno49ZeAj0uQYjVDV2zjwLLpd1itBixDV6UZO3rMZGUZiNpNM=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNic454bi0eb2sJU2GOZZoxkKuRDjQDu6aGvWWq5dOU4YO1c3bnydcCwQjGVKlMhJfLVrb8hEPBdQ3JXsohAlxuDiHm3SZdMm3W-5gb_pDYMZ4ElD9um6rhh8uWy_V6g7fSd7kbVOUZjfT7JH_7rknAxg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPC-87GCd4AUIKK2cUT2TyeWgly0Oz5CJcwC9asRCSZtecku4A-ufvZDeAKpy_UGnG3hNE9yXp2AItLYzOmM-DiYlToUMpk9qFlxDLXwbxLZr9JTYYDa2_Yh9u6kS4IEpZ5JqpCEKZI-nlYmRw4ch0bkw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOk8BXQJdcVC4JjxvxCWfJOizK5RaJe8Y0HeDq62P-PVQB10f-_n1wDBWEY-voZSTBG2TpwpQ6fw6d2SyFk1pNTz7NoLGkNqh7HPjrT4Gg5ikaZmZ0l4oD1fpcXSlyZYq5TZBzxhUDi8UVK=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      },
+      {
+        "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+        "name": "블루리본"
+      }
+    ],
+    "_areaCode": "SICHEONG_GWANGHWAMUN"
+  },
+  {
+    "cafeId": "3456e613-742a-81ba-832d-c748b394872e",
+    "name": "노띵커피 시청점",
+    "nearestStation": "시청",
+    "location": "서울 중구 서소문로 89-20 1동 1층 103호",
+    "price": 3500,
+    "previewImages": [],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+        "name": "블루리본"
+      },
+      {
+        "id": "66002d49-d8f9-4119-99ef-c508ead21371",
+        "name": "KBrC 수상"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      }
+    ],
+    "_areaCode": "SICHEONG_GWANGHWAMUN"
+  },
+  {
+    "cafeId": "3456e613-742a-81c3-b6ef-fdf02f2327f3",
+    "name": "펄시커피",
+    "nearestStation": "동대입구",
+    "location": "서울 중구 동호로20길 34-57 1층 펄시커피",
+    "price": 5800,
+    "previewImages": [
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240901_205%2F1725157605724m0bUr_PNG%2F%25C6%25DE%25BD%25C3%25C4%25BF%25C7%25C7_%25BF%25DC%25BA%25CE1.png",
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20241120_35%2F1732094179717gRbtR_PNG%2FIMG_3796.png"
+    ],
+    "tags": [
+      {
+        "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+        "name": "시그니처"
+      },
+      {
+        "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+        "name": "블렌드"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      },
+      {
+        "id": "45507d6d-9817-4f8c-a23b-2f119d9101d2",
+        "name": "드립커피"
+      }
+    ],
+    "_areaCode": "SINDANG_YAKSU"
+  },
+  {
+    "cafeId": "3456e613-742a-81cf-99c5-c3dd1135f656",
+    "name": "블루보틀 삼청 카페",
+    "nearestStation": "안국",
+    "location": "서울 종로구 북촌로5길 76",
+    "price": 6600,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNkjHFR2a7_qMc0XiZI_4iR5qDTNQvU0pUELbQQkyyHSPBqwrmcw7gq41Fc7l2Y4wd6h4mNu5Zs1qwS-NuUa9iAGHH46LAlN-lyV_-HeOlu_GbR3lQ--5eDYSFIVMZVq8HYdAH2w2ANPlwhLtK6TgobZw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMqmZzrjEriDS4lRCNLPMzujSRPkh2GaV2ooOsNUhZo0Mea5XeVz3dYhP_bJulKDUlv0XF3CgiQ20HegsUscC3retmDSsfMUwaR-opNQiWBEwi4mRPBZYAu9STH0tV_N4zR2qXU0beHudC4iKQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZP4rlsjxH7P-7rJTP55m168D2mtfTkyYxSNKqgcVAo4l4xjjOrrSRr3qBBcd0qWdpAW8WCHHzn11Hh02RBujX2OGgjPdT4Ybk7YI_yrTprOr6YKBKtCzOFS4grfGtu87vRTnks3oBF_TAVzUuWUtDnDEQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPBf3ohKUC986HJqzRr52kdoegJT0kFopKTaSJ0xjXS0P_2f-mkyQgNMEiIq1W0a7nmRGXmb21OxdiIhSpQv420HGkoZ7EC0LIbMfIRmx18AIGDRX00_qWhF9QI4Ds4w9ggQtvjlUchULdipUUg_hTQ4A=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNC4ybh1LSce3U-NgJ1PLlXpAvCR1XKPkh4iwUli_OwxaoR-9_uLu1zXmmXehd5LdLUIa1EfwFt41bFFoIWzu9y7TkqIQu5Eis6WKa5u68SsqjDD4TbkyS5LyG4q0G4132xUALZ2uYL1YiATt0kM07OBw=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      }
+    ],
+    "_areaCode": "JONGRO3GA_ANGUK"
+  },
+  {
+    "cafeId": "3456e613-742a-81d3-ba40-cb1b75933052",
+    "name": "보현커피",
+    "nearestStation": "동대입구",
+    "location": "서울 중구 동호로30길 31 1층",
+    "price": 4000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqEZpwb53dht3D7erbmyf6aXHOApAhnrqNGDQ4eBcRcJEe-PcgNo1mo_QknJxFRcG84x0F4jDeL7TekdTzcJqy7TIVL2kaesSWM=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO5rPVvBHQGuSv1EreGYiNKn1TPcldKn54NmNdwTUwwcre5TtY7Bfvmw5wf28ZW_9nGnFJDFU3bRVEilYBtPaWe6E7oBKFHzMsXQxfkb7pCZNzuBQRKMFrPzAUY5vZQIQeD7yyXklG19pbXy9w=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOq5zvrAXnKmEZx-j9fofU66kmyuqvUu5NJ4QtLHpaujjrtH4jnJJXaVZvBM3vTz53hlldAMUJeItJUYyO2CbNeMhK_YfGwirpZ-GE-IKUS5gvTeA2zdUZR27Yc15zHxZgRsvMk8Yh2GJtEjYQ8wxPQ=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqFemRY_iM0drmwxdotu4V5ccmZPfYDMUTjVTzslDOfjCPe3eL-uTDjS8pwFvZD1RQPDtRZawZ59diNTZcZcame2NFhtdOqxceA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPajCeoAWCkwaowTpIj-CcKCmSbKYXIIa2rYzE-h1vo548n38WNEIJO1u9VVSr3dRVP_6qNHpuI-ICH5YCRTlI7sc1Csb1y_uozsKzApDH4Mhwm5Cz70D1RLTsmQe6vJkt_2E8mhyJuVF7yOmghoJQ8=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "1ead9a26-ab24-4d5b-b046-4af8636f6b97",
+        "name": "매니아"
+      },
+      {
+        "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+        "name": "시그니처"
+      },
+      {
+        "id": "45507d6d-9817-4f8c-a23b-2f119d9101d2",
+        "name": "드립커피"
+      }
+    ],
+    "_areaCode": "CHUNGMURO_EULJIRO"
+  },
+  {
+    "cafeId": "3456e613-742a-81d7-b08d-dda44d80c230",
+    "name": "포트레이트커피바",
+    "nearestStation": "망원",
+    "location": "서울 마포구 포은로8길 32 1층",
+    "price": 0,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqHV0ZB0vrL1_RJtdlrDo7rqgZOTHgDWa0yOPKDmIpMDnJ_CcM-BEYE4Dz7Em1iV6R6HtWiVbz6gwsRLfCjqY8tkiwfr7W2Url4=s4800-w555",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN7FDsq0L1wuEO2zY4x9jXuyVHQW9jibF5VhkL8VG_EejfgHKC2vki6koiLpBCeFaSKbyrJjosYUAZcLOwafiiNXEqH8ISgEaktUuFsq5N0s6IdSPutmwrZmw0cdVaQ1f2lNLxjyndWKD1xGhcAoLHVHA=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqF9rplZyAbp0kl4Gp63T_64gigPhco2GcqmoLxdGs7a5b7PtP1MPIgQgE_Q3Ss3ZsrQrgVTXEPRvwrg9v0QCQLv3RN_DNBUPtM=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqFlLKPDIF_658OaNRCvfOwpPHIVyYOJQXNPJhEHc13p3rMMob-DnArck73AaLsldu6H55WS_O9I-ie5zjRgPKzb1EFQi8g2vII=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqGwP-W1ij0yaSpuwZiLluBkrtCOb-5JIWCJxPLpDbxoDjaS0MuvWPzQkZ1rel7kn1r6nQXS-S-R2RWAx5phTo0UDMjs4a-9XzE=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+        "name": "대중적인"
+      },
+      {
+        "id": "0921cf45-93af-400b-a9ed-0b85a194f812",
+        "name": "산미"
+      },
+      {
+        "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+        "name": "필터 맛집"
+      },
+      {
+        "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+        "name": "시그니처"
+      }
+    ],
+    "_areaCode": "MANGWON"
+  },
+  {
+    "cafeId": "3456e613-742a-81e5-8e15-f523eaff7d4a",
+    "name": "업사이드커피 약수점",
+    "nearestStation": "약수",
+    "location": "서울 중구 동호로10길 42 1층",
+    "price": 5000,
+    "previewImages": [
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230629_8%2F1688001957512bTny5_JPEG%2FIMG_1839.jpeg",
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240528_138%2F1716859832976ssjuR_JPEG%2FIMG_2483.jpeg",
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240528_48%2F1716859832359RpYbq_JPEG%2FIMG_3858.jpeg"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+        "name": "대중적인"
+      },
+      {
+        "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+        "name": "라떼 맛집"
+      },
+      {
+        "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+        "name": "시그니처"
+      }
+    ],
+    "_areaCode": "SINDANG_YAKSU"
+  },
+  {
+    "cafeId": "3456e613-742a-81e7-a47a-e5cda7abe514",
+    "name": "챔프커피 제3작업실",
+    "nearestStation": "을지로3가",
+    "location": "서울 중구 을지로 157 라열 3층 381호",
+    "price": 5000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNWvpgkp3KX_oXfgqKz91fYJjxRh16VQbXO5sxnGjaJZQ4E7aU_y5mCS1_OF0yumd1q1WIkE4YYoZamvkAic0dacJKvwMqlcUddKxh5VIaGQu5bj5czJoU9XlriWFOclrrSj5f8QYnqi8MP288P1aJ20g=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZORff_9k2a_ynMozag6pswmbJvA6y6TLmTA0pwMcW3sGB9gb4xy5C8tlwDCLS5KKTNMpmk2lIc_1GbKEOaNd3k0tmhVPMNVGPm7e39cBZn5kDm1fkzFcf-RmF4UI3Wbm1tgVwLFpW-aK0ikqmc=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNF4Xj6WaUDVuk4LeY4wE5YHzdq_FMGmvb7S6OY2KL5RXvOQE0Jn5EP94yHYyfkiu8sIaLQzSukRpobrvZkQzlduQSltm1rYLvPt_1JIMQIlxX9l1PEXFAQc4I74DLOvZFgEdM6-IBWscDqdwfbhAxl=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOvVuuVEJKMB1TFhtwHgn6A19yPrtA_FNhGffmJtqJx_R6aFlnZoAfezjvkmQTkDUEY_vAtvRtXUM1OFoPPifZxqDlZ8-7_CtKo2IdYYDx3qp2YuD5okgTa48DGnHjbe0e17jKsikYxn-63EA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO4dcxx5msH_ojgAZi_mSIfodZOznmfyALTak9LZ90gkV7o-VHlpW9Wj9OkWXlmFqd9wDvsgrheBeYLpI0WsU1hwAZkUVdbDuEg04HUyTpNAxz-un7WtWlaYzmr-V0ZPqUQpUVOX5XownngYr0TKHElSg=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+        "name": "브랜드"
+      },
+      {
+        "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+        "name": "대중적인"
+      },
+      {
+        "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+        "name": "라떼 맛집"
+      },
+      {
+        "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+        "name": "블렌드"
+      }
+    ],
+    "_areaCode": "CHUNGMURO_EULJIRO"
+  },
+  {
+    "cafeId": "3456e613-742a-81ec-a7e8-fc3e1001a29e",
+    "name": "맥컬리커피",
+    "nearestStation": "을지로3가",
+    "location": "서울 중구 충무로5길 6-1 2층",
+    "price": 4800,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqFnO3ToAZInMXVimYPISzXs0lO6lx9SqA2xAVu52Hw1lJ2V6V8tlENT1bbdS8bpmI69WbUuVyfVCsWtkEJ_2XmZFMkcksFZkOc=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqFw5tcc9A7LHMTbgyXvs3Ir6INXj2lT1-_SHuW7SXAhImRQSNdn1MsmhCfoX_K6neHvpX9IXTIOc4c6LvHytQk3oNTXNUiGhsA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNfsT7yey1TOfVfrlojBHSXKycTduNBlscPCq-tNNDMCpgcIjhk12pXydkyBc1MVaCsn41ika5BbckH4a5SvFdbvaXlT9aAeHQ2Ehsz6K0TsIVy8WOuf_Ik1QQd0MUVDmyI95L0aVotqTOaFqDXmzY9=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN6-VllYGwM-ZA1ebxYjdG8W8Yh31vcp55HLcqqCaSq1yva05vSBJtgYfPRw4OXiHXr25QW31IAGbZ7G3TbudS2nuhnHFzxUiu_QdJzd27kNjh1zZ0joNlpUjJcaSPQOX97hs04Kbc3G5xvV1RTwJiUPQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZP6985M49UnQz8o_MvWbknVcbWmH_ECUJj-fupQ7hrcNzLF6lh9od8qsWDzAfRmFSjwC8rXQE4E-ugZ8nioA1pT275pX9AmwgSEyVinBkq6J_MtVhCNd1gOJTTF5dwiJFVxiXdYSLI3bT7QDw=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+        "name": "대중적인"
+      },
+      {
+        "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+        "name": "라떼 맛집"
+      },
+      {
+        "id": "0bf60d10-7f76-424f-97f3-4450ad284d73",
+        "name": "과일"
+      },
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      }
+    ],
+    "_areaCode": "CHUNGMURO_EULJIRO"
+  },
+  {
+    "cafeId": "3456e613-742a-81ee-ace8-c0d60cf1860f",
+    "name": "써밋컬쳐 신촌",
+    "nearestStation": "신촌",
+    "location": "서울 마포구 신촌로14안길 11 엘루체 102호 SUMMIT 신촌점",
+    "price": 4800,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGHEyQbmHIUAMC4AR3ow2j5G4V-Rn1B9JDLTP0j1kttYjIeCIra1CT9E66adjwaHSxbSEu9wCzHe9aXx8Mfe7YWtq84Qant990=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNiuoX5Bx0p-0wQaPReT_0mn9Vdw0SK8ic9RlGIRge9MQLyGxyh7hXN6-B4ZaVt6C-uLTyDBNyERyCZbWJlN6pZEd0wCfJMf-4ugZZ89h86FmgH1wNuIrh3eaBn27haV1Ismi1FrxyL3ieWnno=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPIzYZNg11yD78e5jgIqdBs-EvQMeGq3zysoQEClRmyt1NvKHecUfewRti7jHhlgdP6cf95RjBS26hoAaKroLAZRqCLdq7gI1XrdvfJEuM9WAVVS63U_cHUFu-bH0Gf3BKXiXPvC-nsymgqUA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMIHx4YVNS7HFPK8BoGeykZX9Q6LtGciQEHo9bAKtYKEOqoETqrQUpFCsv6wNjcfVa5vZRoKyMPooWj-x0dwKQbwvtGhz7n0l78ZZf9BN6xGa9MacPU35TZOWRTFHnGRKOPlmThK3ULvJnCLHE=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMoxX1QSjn8m6aGQ8X5TxOM0ln65z66S0dE_r4rLPLSUqa_o-k6M1pskoS4QOhfVP4dru9DHN9s8fH5lEnGVGZqJVek4eFD10ZqRsb51Mz1m0BqFFMtIWsWaSbFNURHGxb5JiYxLbUx0kPeZ14mfPfBMw=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+        "name": "블루리본"
+      },
+      {
+        "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+        "name": "시그니처"
+      },
+      {
+        "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+        "name": "대중적인"
+      },
+      {
+        "id": "45507d6d-9817-4f8c-a23b-2f119d9101d2",
+        "name": "드립커피"
+      }
+    ],
+    "_areaCode": "SINCHON_HONGDAE"
+  },
+  {
+    "cafeId": "3456e613-742a-81f9-9628-e740514d4c20",
+    "name": "딥블루레이크",
+    "nearestStation": "망원",
+    "location": "서울 마포구 포은로6길 11",
+    "price": 6000,
+    "previewImages": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOXoom62MK8N_m7T8xw9r_r6m30elu4Otmky-kBHx1faN1wLqoPnSJxK5ggQfATRy_4X0EcGj6DbFIHE725djstgqOsD8kBNoy_8D32CCPd6Quiaam5Hrdh6Y9ifZbXuaaJbj9VDKERBM3xq14=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPFdnBzUShwrktP7k8F1eLlJpABsjfWeXfrTAtHZLEgsYEU4ZdDeARgtUEpri5433uklU0MvCs70NdtepPYZiHyxM87JDJOImnFnojDGRGzhzk7hyjBnphhhHqOG3fzzHJHfeBygIZkfNqekA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMv-agOLPm7E8E_GRZoB27D1DAXVZ3LLrYV8IS6-fZec4FrCqxQ4-9la5Hbdpfo0hfQ_GgwMOwWWNM3H3Uu3ZQCyx2OXMpg0UBUMut9ry0pe8l_1crDFXTBpaGk20LLuS47nNOlA8Bj6ABPGBRRGFnF9g=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOT4ouVY9hCwBuOex95yzTC2V8vhQhPdvtCD1YvhG3_l-bUHRNjd6525kCsSfk0m-O7mo_VYzOqxmN35byC7b_YvjPLFA-aBOjemVR6GvBX7Qj3mAiiVv-4u9xLYruKiiEMnOQfI8HC3FpEF0lIol_f-Q=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPal6wubao-zRXE1k55ERJjkZuO4hYiYNSEQ9IBu-Xxyfii532uj5MZ5QrdBCbKOAb7hL8X47uMzBqi9PhmQd8gOrjQRXZhztterxI71N4GcyommoEwVRcQBXJIrzoeOPidbp_wS_H6GM1a7hcOdHvEMA=s4800-w800"
+    ],
+    "tags": [
+      {
+        "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+        "name": "싱글오리진"
+      },
+      {
+        "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+        "name": "라떼 맛집"
+      }
+    ],
+    "_areaCode": "MANGWON"
+  }
+]

--- a/public/data/details/3456e613-742a-8105-a51b-f7ef853d6b45.json
+++ b/public/data/details/3456e613-742a-8105-a51b-f7ef853d6b45.json
@@ -1,0 +1,110 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8105-a51b-f7ef853d6b45",
+    "reasonForSelection": "스페셜티 커피 매장. 카페 내부 공간은 협소한 편이지만 좋은 품질의 커피를 선보인다. 상시 10종류의 싱글 오리진 커피를 보유하고 있으며, 취향에 따라 원두 선택부터 에스프레소, 필터, 밀크커피까지 다양하게 선택할 수 있는 것이 특징",
+    "naverMapUrl": "https://naver.me/5iTd6abU",
+    "name": "트레머 커피웍스",
+    "nearestStation": "홍대입구",
+    "location": "서울 마포구 와우산로29다길 11-1 지1층",
+    "price": 0,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNVzF3tI0t0FkJBkRM5mz4fi2xUIu6Cgv1hZcnp65lZtdcBsfy-l2GR7hQU6rVoJaP2h7cOM8H-xgVtDtYvvI6_zfPGF1Swt_KxRjN9WXLqhHpLG92ACM1fZwrkMxSzgXjOeFfeAZ-J2rHuyQ=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "John Swift",
+        "uri": "https://maps.google.com/maps/contrib/103902733045144332915"
+      },
+      {
+        "displayName": "Anna Zhilina",
+        "uri": "https://maps.google.com/maps/contrib/100943356577614589388"
+      },
+      {
+        "displayName": "Agnieszka Witczak",
+        "uri": "https://maps.google.com/maps/contrib/115311569956998214591"
+      },
+      {
+        "displayName": "Ricehon",
+        "uri": "https://maps.google.com/maps/contrib/101812471017667912990"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8105-a51b-f7ef853d6b45-bean",
+    "description": "남녀노소 좋아할만한 미디엄 다크 로스팅의 커피입니다. 카카오의 쌉싸래한 맛과 적사과의 은은한 향이 조화를 이루며, 구운 마카다미아와 밀크초콜릿의 부드러운 여운을 남깁니다.",
+    "name": "골든 아워 블렌드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "카카오닙스",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "사과",
+        "category": "Fruity"
+      },
+      {
+        "name": "밀크 초콜릿",
+        "category": "Nutty/Cocoa"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "브라질",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "인도네시아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8105-a51b-f7ef853d6b45-m1",
+      "name": "핸드드립",
+      "price": 0,
+      "imageUrl": "",
+      "description": "트레머커피웍스의 모든 커피는 원두를 먼저 선택 후, 추출 방식을 선택해서 드실 수 있습니다"
+    },
+    {
+      "id": "3456e613-742a-8105-a51b-f7ef853d6b45-m2",
+      "name": "더웍스",
+      "price": 20000,
+      "imageUrl": "",
+      "description": "트레머 커피웍스의 주요 세 가지 메뉴를 순서대로 맛볼 수 있는 커피 플래터입니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+      "name": "블루리본",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    },
+    {
+      "id": "c5c030e2-74f2-4031-bbfa-7573231b9121",
+      "name": "에스프레소 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-29"
+}

--- a/public/data/details/3456e613-742a-8106-ba14-cf8ebd0f069c.json
+++ b/public/data/details/3456e613-742a-8106-ba14-cf8ebd0f069c.json
@@ -1,0 +1,93 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8106-ba14-cf8ebd0f069c",
+    "reasonForSelection": "차별화된 맛을 제공하기 위해, 손이 많이 가더라도 직접 제작한 기구를 사용하여 융드립 커피를 내리는 카페입니다. 숯불로 볶은 원두도 경험할 수 있습니다.",
+    "naverMapUrl": "https://naver.me/xExW9583",
+    "name": "피피커피",
+    "nearestStation": "망원",
+    "location": "서울 마포구 동교로 23 1층",
+    "price": 7000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPq6s-zDH5TvI-D_3-Q_-qm_JxmYhOv7mCLVMk4tco4M_H4q1Gsy5P2lk8DhlF_SNuhApKZE5BKMeBtb38juIDDxeonpwPxGZ7vf_JvawXqD_24Um3lVlLUgE87kr7_yUE5p4Me7Q-2kup2BA=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "SK. Lee",
+        "uri": "https://maps.google.com/maps/contrib/100330785291388672862"
+      },
+      {
+        "displayName": "EUNJEONG CHO",
+        "uri": "https://maps.google.com/maps/contrib/102848365565532411199"
+      },
+      {
+        "displayName": "Virak Horn",
+        "uri": "https://maps.google.com/maps/contrib/110877812762636938895"
+      },
+      {
+        "displayName": "이연숙",
+        "uri": "https://maps.google.com/maps/contrib/113102366656449143137"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8106-ba14-cf8ebd0f069c-bean",
+    "description": "비옥한 토양과 좋은 기후를 가진 모모라 농장에서 재배되었습니다. 향긋한 산미와 달콤하고 고소한 향미를 즐길 수 있는 원두입니다.",
+    "name": "에티오피아 모모라 내추럴 구지",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "다크 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "복숭아",
+        "category": "Fruity"
+      },
+      {
+        "name": "체리",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "DARK"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8106-ba14-cf8ebd0f069c-m1",
+      "name": "융드립 Ice",
+      "price": 7000,
+      "imageUrl": "",
+      "description": "융드립 방식으로 정성스럽게 내려 풍부한 맛과 향을 지닌 한 잔."
+    },
+    {
+      "id": "3456e613-742a-8106-ba14-cf8ebd0f069c-m2",
+      "name": "아메리카노 Ice",
+      "price": 5000,
+      "imageUrl": "",
+      "description": "기본에 충실하면서도 평범하지만은 않은 아메리카노."
+    }
+  ],
+  "tags": [
+    {
+      "id": "1ead9a26-ab24-4d5b-b046-4af8636f6b97",
+      "name": "매니아",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "c5c030e2-74f2-4031-bbfa-7573231b9121",
+      "name": "에스프레소 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-25"
+}

--- a/public/data/details/3456e613-742a-810c-9314-c6c3dca0c7d0.json
+++ b/public/data/details/3456e613-742a-810c-9314-c6c3dca0c7d0.json
@@ -1,0 +1,109 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-810c-9314-c6c3dca0c7d0",
+    "reasonForSelection": "로스터리 카페로 스페셜티 커피를 진정성있게 다루며, 다수의 커피 대회 수상 이력을 쌓으며 커피에 진심을 다 하는 카페입니다. 단순히 커피만 잘하는 곳을 넘어 아늑한 공간과 매일 정성스럽게 만든 수제 디저트로 만족을 드리기 위하여 노력하는 공간입니다.",
+    "naverMapUrl": "https://naver.me/FxFtoMUT",
+    "name": "커넥츠커피 망원",
+    "nearestStation": "망원",
+    "location": "서울 마포구 월드컵로11길 8 105호 커넥츠커피 망원점",
+    "price": 5000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMoDd1eUjM-E7MDr0eLoMPgHxMs83lDUq_dxusWDfbRcOvm2EPMu6poLZ7rC4OvmVhQTuuv7-2XQf9RVssrH5qdr6UbzRNbgJSvUmmto_CcDs81-80qb9uXZDtyqm7Kwh2qD9eEpmPis8fAqA=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "홍",
+        "uri": "https://maps.google.com/maps/contrib/109540277806552877850"
+      },
+      {
+        "displayName": "뚜뚜루뚜뚜",
+        "uri": "https://maps.google.com/maps/contrib/116053173347867842673"
+      },
+      {
+        "displayName": "ree T",
+        "uri": "https://maps.google.com/maps/contrib/113968091913809736158"
+      },
+      {
+        "displayName": "JINU YOUN",
+        "uri": "https://maps.google.com/maps/contrib/112925352849439490899"
+      },
+      {
+        "displayName": "ruin Sung Mean Pae",
+        "uri": "https://maps.google.com/maps/contrib/102778409927121337507"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-810c-9314-c6c3dca0c7d0-bean",
+    "description": "건과일이나 조청류의 단맛을 느낄 수 있고, 단조롭지 않은 다양한 풍미가 맛을 더욱 풍부하게 표현합니다. 맛의 균형감이 뛰어나면서 부담 없는 적당한 산미를 가진 부드러운 커피를 찾으시는 분께 추천합니다.",
+    "name": "커넥츠 블렌드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "흑설탕",
+        "category": "Sweet"
+      },
+      {
+        "name": "오렌지",
+        "category": "Fruity"
+      },
+      {
+        "name": "건과일",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "과테말라",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "인도",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-810c-9314-c6c3dca0c7d0-m1",
+      "name": "커넥츠 커피",
+      "price": 5000,
+      "imageUrl": "",
+      "description": "달콤한 크림이 올라간 부드러운 밀크 커피입니다."
+    },
+    {
+      "id": "3456e613-742a-810c-9314-c6c3dca0c7d0-m2",
+      "name": "아메리카노",
+      "price": 4500,
+      "imageUrl": "",
+      "description": "발렌타인(다크 초콜릿, 고소한 맛), 커넥츠(밸런스, 흑설탕), 프루티(산뜻, 잘 익은 과일) 디카페인 변경 가능."
+    }
+  ],
+  "tags": [
+    {
+      "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+      "name": "블루리본",
+      "imageUrl": ""
+    },
+    {
+      "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+      "name": "대중적인",
+      "imageUrl": ""
+    },
+    {
+      "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+      "name": "라떼 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-25"
+}

--- a/public/data/details/3456e613-742a-810c-acae-d08ae2fbcf73.json
+++ b/public/data/details/3456e613-742a-810c-acae-d08ae2fbcf73.json
@@ -1,0 +1,94 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-810c-acae-d08ae2fbcf73",
+    "reasonForSelection": "국내 스페셜티 커피 1호인 커피리브레는 대한민국 최초의 커피 품질 감별사인 서필훈 큐그레이더가 이끄는 스페셜티 커피 브랜드입니다. 니콰과라의 핀카 리브레 농장을 운영합니다. 직접 운영하는 농장에서 재배해 신선한 싱글 오리진을 경험하실 수 있습니다.",
+    "naverMapUrl": "https://naver.me/GEXvg9SP",
+    "name": "커피리브레 파란점",
+    "nearestStation": "홍대입구",
+    "location": "서울 마포구 성미산로29길 17-8 지하1층, 1, 2층",
+    "price": 5000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqE5eHmZGdw7P5_mCUk3g9v8IZy0-e2QYQIOAZ8ovRwjQdCXGol3vPPVem5rwMYQiuWpxk-KWFS0WbGbbswxQX-D1w_FuxjD-Xo=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "커피 리브레 파란점",
+        "uri": "https://maps.google.com/maps/contrib/106611001321070135527"
+      },
+      {
+        "displayName": "4885",
+        "uri": "https://maps.google.com/maps/contrib/101174457893511364385"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-810c-acae-d08ae2fbcf73-bean",
+    "description": "골드문트는 독일어로 ‘황금입술’이라고 합니다. 최고급 라인업으로 분류되는 이 커피는 게이샤 품종으로, 풍부한 향과 깔끔한 맛을 특징으로 합니다.",
+    "name": "[골드문트] 콜롬비아 나리뇨 라 레이나 벨렌 게이샤",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "자스민",
+        "category": "Floral"
+      },
+      {
+        "name": "패션후르츠",
+        "category": "Fruity"
+      },
+      {
+        "name": "오렌지 블라썸",
+        "category": "Floral"
+      },
+      {
+        "name": "블루베리",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-810c-acae-d08ae2fbcf73-m1",
+      "name": "싱글오리진",
+      "price": 5000,
+      "imageUrl": "",
+      "description": "싱글오리진 원두로 내리는 드립커피입니다."
+    },
+    {
+      "id": "3456e613-742a-810c-acae-d08ae2fbcf73-m2",
+      "name": "에스프레소",
+      "price": 4500,
+      "imageUrl": "",
+      "description": "에스프레소 머신으로 추출한 커피입니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    },
+    {
+      "id": "0bf60d10-7f76-424f-97f3-4450ad284d73",
+      "name": "과일",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-29"
+}

--- a/public/data/details/3456e613-742a-8112-9bcd-d1a2b77758c2.json
+++ b/public/data/details/3456e613-742a-8112-9bcd-d1a2b77758c2.json
@@ -1,0 +1,86 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8112-9bcd-d1a2b77758c2",
+    "reasonForSelection": "상호명에서 알 수 있듯이 직접 로스팅을 한 원두로 커피를 내주는 로스터리 카페 입니다. 바테이블 형식이며, 샴페인 잔에 커피를 담아주는 독특한 특징이 있습니다.",
+    "naverMapUrl": "https://naver.me/G9r5J3zu",
+    "name": "로투스 로스팅랩",
+    "nearestStation": "신당",
+    "location": "서울 중구 퇴계로83길 30-14 1층 로투스 로스팅랩",
+    "price": 5000,
+    "mainImageUrl": [
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220416_166%2F1650082800337GAMGh_JPEG%2FLOTUS_%25BF%25F8%25C7%25FC%25B5%25F0%25C0%25DA%25C0%25CE01.jpg",
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230825_97%2F16929688374889edAV_JPEG%2FIMG_5918.jpeg"
+    ],
+    "imageAttributions": []
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8112-9bcd-d1a2b77758c2-bean",
+    "description": "아몬드와 밀크초콜렛 같은 견과류와 편안함. 언제나 데일리 커피로 가능합니다. 우유와 함께 섞이는 커피에 에스프레소용으로 사용하기 좋은 고소한 맛의 원두입니다.",
+    "name": "볶블렌드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "아몬드",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "밀크 초콜릿",
+        "category": "Nutty/Cocoa"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "브라질",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "과테말라",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8112-9bcd-d1a2b77758c2-m1",
+      "name": "LO+US Latte",
+      "price": 5000,
+      "imageUrl": "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240207_182%2F1707297938991FMocE_JPEG%2FIMG_8703.jpeg",
+      "description": "스페셜티 커피 에스프레소+티 느낌이 나는 우유. 밀크티 느낌이 나는 카페라떼."
+    },
+    {
+      "id": "3456e613-742a-8112-9bcd-d1a2b77758c2-m2",
+      "name": "Granita",
+      "price": 5500,
+      "imageUrl": "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230829_219%2F1693296774847llUIs_JPEG%2FAE28906D-3AF2-4556-A6BD-1D362DE76685.jpeg",
+      "description": "스페셜티 커피 에스프레소+오렌지 샤베트. 시원, 상큼, 달달한 디저트 음료."
+    }
+  ],
+  "tags": [
+    {
+      "id": "c5c030e2-74f2-4031-bbfa-7573231b9121",
+      "name": "에스프레소 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "66002d49-d8f9-4119-99ef-c508ead21371",
+      "name": "KBrC 수상",
+      "imageUrl": ""
+    },
+    {
+      "id": "0921cf45-93af-400b-a9ed-0b85a194f812",
+      "name": "산미",
+      "imageUrl": ""
+    },
+    {
+      "id": "45507d6d-9817-4f8c-a23b-2f119d9101d2",
+      "name": "드립커피",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-27"
+}

--- a/public/data/details/3456e613-742a-8117-998a-e76b75241b88.json
+++ b/public/data/details/3456e613-742a-8117-998a-e76b75241b88.json
@@ -1,0 +1,105 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8117-998a-e76b75241b88",
+    "reasonForSelection": "을지로의 터줏대감인 커피 한약방은 원두의 종류와 등급을 구분해 ‘필터 커피’와 ‘필터 스페셜’을 제공합니다. 여전히 직접 로스팅하는 대표인 강윤석 로스터는 베테랑 연극배우이기도 합니다. 오래된 혜민당의 역사만큼, 커피 한약방은 을지로 커피의 역사로 남아있습니다.",
+    "naverMapUrl": "https://naver.me/5WOQhh9r",
+    "name": "커피한약방",
+    "nearestStation": "을지로3가",
+    "location": "서울 중구 삼일대로12길 16-6",
+    "price": 0,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNp3w0uyaLAXXoned2nURVQL8iMBiH08O61of7a6sdd6n2vxJjYjH9sJFJtCs2joCfiZbYOeb-k35Rx6nfzCsbpYzvYUeW8v9bWM09q-P8A4NPVdvSmjIQtDbb9jwe1uChdSrbbpCzcb1eF=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "一起玩生活",
+        "uri": "https://maps.google.com/maps/contrib/118205409563621553270"
+      },
+      {
+        "displayName": "Kyung-Jun Lee",
+        "uri": "https://maps.google.com/maps/contrib/111248486244811888553"
+      },
+      {
+        "displayName": "Jo “gorby” L",
+        "uri": "https://maps.google.com/maps/contrib/109986623119636476956"
+      },
+      {
+        "displayName": "Bartek",
+        "uri": "https://maps.google.com/maps/contrib/109741509203395903561"
+      },
+      {
+        "displayName": "김정호",
+        "uri": "https://maps.google.com/maps/contrib/115353743468053479499"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8117-998a-e76b75241b88-bean",
+    "description": "직화 로스팅한 시그니처 블랜드입니다. 달콤 쌉싸름한 다크초콜릿의 맛과 텁텁하지 않은 스모키 한 향이 부드럽게 입안을 감쌉니다.",
+    "name": "동네어귀 방앗간 블렌드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "스모크",
+        "category": "Roasted"
+      },
+      {
+        "name": "다크 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "라운드",
+        "category": "Other"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "인도네시아 만델링",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "케냐 니에리 레드마운팅",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "에티오피아 아리차",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "DARK"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8117-998a-e76b75241b88-m1",
+      "name": "필터커피",
+      "price": 0,
+      "imageUrl": "",
+      "description": "핸드드립 방식의 필터 커피입니다."
+    },
+    {
+      "id": "3456e613-742a-8117-998a-e76b75241b88-m2",
+      "name": "필터스페셜",
+      "price": 0,
+      "imageUrl": "",
+      "description": "핸드드립 방식의 필터 커피입니다. 선별된 특별한 원두들을 필터 스페셜이라고 부릅니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+      "name": "블루리본",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+      "name": "블렌드",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": null
+}

--- a/public/data/details/3456e613-742a-811c-b069-cda489e0a9dc.json
+++ b/public/data/details/3456e613-742a-811c-b069-cda489e0a9dc.json
@@ -1,0 +1,88 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-811c-b069-cda489e0a9dc",
+    "reasonForSelection": "아마츄어는 단순한 커피 로스터가 아니라 진정한 커피에 대한 열정을 가진 장인적 접근을 보여줍니다. 그들은 기계적 대량 생산이 아닌 정성과 섬세함을 담아 원두를 로스팅합니다.",
+    "naverMapUrl": "https://naver.me/5tJCNria",
+    "name": "아마츄어작업실 청계점",
+    "nearestStation": "을지로3가",
+    "location": "서울 종로구 청계천로 97-8",
+    "price": 9500,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN9AX14pFZwXCu7y_revxvj42dbrGXbAU1_o1ELnYF2J85R_YeIgiHjWNW8CXdnSwc80ajJikaImOL_Bq_H5-QcN0tMVVb0BUhu1D91SkP8o6vSYopvffM3Wi3Y0rNf7ySeMokdkfAOykfz=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "이주원",
+        "uri": "https://maps.google.com/maps/contrib/113108122614507003609"
+      },
+      {
+        "displayName": "예지앞사",
+        "uri": "https://maps.google.com/maps/contrib/107087717340452475497"
+      },
+      {
+        "displayName": "환환",
+        "uri": "https://maps.google.com/maps/contrib/107790157174004513891"
+      },
+      {
+        "displayName": "EUNJEONG CHO",
+        "uri": "https://maps.google.com/maps/contrib/102848365565532411199"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-811c-b069-cda489e0a9dc-bean",
+    "description": "콜롬비아 라 루이산원두는 안티오키아 지방의 고산 지대에서 재배되는 고품질 아라비카 커피입니다. 이 원두는 1,500에서 1,800미터 사이의 고도에서 자라며, 워시드 프로세스로 가공됩니다",
+    "name": "콜롬비아 라 루이산 무산소 발효",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "과일",
+        "category": "Fruity"
+      },
+      {
+        "name": "시트러스",
+        "category": "Fruity"
+      },
+      {
+        "name": "시나몬",
+        "category": "Spices"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-811c-b069-cda489e0a9dc-m1",
+      "name": "주인장 커피",
+      "price": 9500,
+      "imageUrl": "",
+      "description": "요거트 발효향의 상큼한 향미를 느낄 수 있는 드립 커피"
+    },
+    {
+      "id": "3456e613-742a-811c-b069-cda489e0a9dc-m2",
+      "name": "내 이름은 알롱시",
+      "price": 9500,
+      "imageUrl": "",
+      "description": "기분 좋은 산딸기의 향미를 느낄 수 있는 드립커피"
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "45507d6d-9817-4f8c-a23b-2f119d9101d2",
+      "name": "드립커피",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-28"
+}

--- a/public/data/details/3456e613-742a-8121-a957-fc1f5cb28894.json
+++ b/public/data/details/3456e613-742a-8121-a957-fc1f5cb28894.json
@@ -1,0 +1,106 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8121-a957-fc1f5cb28894",
+    "reasonForSelection": "커피의 수확부터 한 잔의 커피에 이르기까지, 수많은 과정을 거칩니다. 커피와 그 한 잔을 즐기는 사람이 전부인 공간. 펠트는 오직 커피만을 위한 과정에 집중하는 카페입니다. 매년 직접 산지를 방문하여 생두를 선별하고, 가장 절정의 맛을 담습니다.",
+    "naverMapUrl": "https://naver.me/GG7tHMB7",
+    "name": "펠트커피 청계천점",
+    "nearestStation": "광화문",
+    "location": "서울 중구 청계천로 14",
+    "price": 4500,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO4N7B2-f52cmt-tYwM42IITAf5LFPG74_8I3Py3HgY9_39QMy-pu9Y8SOGVm47H3q3QvvNnBGYPotci5C3JD534Du-ZCdR80LaAcfGUAY3cutmdWMBwPO_1v1ZZl-fmGeg6AywsTZVJVIG8ys=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "송명후",
+        "uri": "https://maps.google.com/maps/contrib/112462352094917846513"
+      },
+      {
+        "displayName": "A",
+        "uri": "https://maps.google.com/maps/contrib/114273467874530356771"
+      },
+      {
+        "displayName": "Dariusz G",
+        "uri": "https://maps.google.com/maps/contrib/100972152106159291910"
+      },
+      {
+        "displayName": "KS Choi (Gravity15)",
+        "uri": "https://maps.google.com/maps/contrib/111676510720878147594"
+      },
+      {
+        "displayName": "Greysuitcase",
+        "uri": "https://maps.google.com/maps/contrib/115915227251650202552"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8121-a957-fc1f5cb28894-bean",
+    "description": "낮은 톤의 산미, 밀크초콜렛과 다크초콜렛을 넘나드는것 같은 묵직하고 달콤함이 돋보이는 에스프레소. 누구나 편하게 즐길수 있는 균형감 있는 커피.",
+    "name": "펠트 커피 클래식 에스프레소",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "밀크 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "다크 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "고소한",
+        "category": "Other"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "코스타리카",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "DARK"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8121-a957-fc1f5cb28894-m1",
+      "name": "에스프레소",
+      "price": 4500,
+      "imageUrl": "",
+      "description": "고온·고압의 추출 방식으로 커피의 진한 풍미와 크레마를 즐길 수 있는 커피"
+    },
+    {
+      "id": "3456e613-742a-8121-a957-fc1f5cb28894-m2",
+      "name": "브루드 커피",
+      "price": 6500,
+      "imageUrl": "",
+      "description": "뜨거운 물을 이용해 원두의 풍미를 우려내는 방식으로 추출된 커피."
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "0921cf45-93af-400b-a9ed-0b85a194f812",
+      "name": "산미",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-24"
+}

--- a/public/data/details/3456e613-742a-812e-b998-ecb84f92fe35.json
+++ b/public/data/details/3456e613-742a-812e-b998-ecb84f92fe35.json
@@ -1,0 +1,98 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-812e-b998-ecb84f92fe35",
+    "reasonForSelection": "계절이나 상황에 따라 커피와 디저트를 직접 선정하여 제공하는 카페입니다. 아늑한 분위기의 공간에서 정성스럽게 준비한 커피와 디저트를 경험해 보세요.",
+    "naverMapUrl": "https://naver.me/FPnrr9Xa",
+    "name": "평형",
+    "nearestStation": "망원",
+    "location": "서울 마포구 포은로5길 6 1층",
+    "price": 5000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqEF3B7WteHj1IhJfhJ3g-DM8r4pTmdhoXDdjpjVvb8GNg_7ZxtEN-g3yn7OxFbSknMiSRUijdesImFveGx9uYGjCmLXyx33bRo=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "평형",
+        "uri": "https://maps.google.com/maps/contrib/103391835054553483549"
+      },
+      {
+        "displayName": "A",
+        "uri": "https://maps.google.com/maps/contrib/114273467874530356771"
+      },
+      {
+        "displayName": "Sesame Sprinkles",
+        "uri": "https://maps.google.com/maps/contrib/114630405221931250347"
+      },
+      {
+        "displayName": "이동윤 (폭스마피아)",
+        "uri": "https://maps.google.com/maps/contrib/110412043580559528745"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-812e-b998-ecb84f92fe35-bean",
+    "description": "땅콩, 호두의 고소한 향과 다크 초콜릿의 중후한 향이 어우러지는 원두입니다. 스모키하고 달콤쌉싸름한 맛이 특징입니다.",
+    "name": "과테말라 후에후에테낭고",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "땅콩",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "호두",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "다크 초콜릿",
+        "category": "Nutty/Cocoa"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "과테말라",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-812e-b998-ecb84f92fe35-m1",
+      "name": "과테말라 후에후에테낭고",
+      "price": 5000,
+      "imageUrl": "",
+      "description": "호두, 시리얼, 다크 초콜릿의 향미를 지닌 커피."
+    },
+    {
+      "id": "3456e613-742a-812e-b998-ecb84f92fe35-m2",
+      "name": "에티오피아 예가체프",
+      "price": 5500,
+      "imageUrl": "",
+      "description": "플로럴, 레드베리, 레몬티의 향미를 지닌 커피."
+    }
+  ],
+  "tags": [
+    {
+      "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+      "name": "대중적인",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "0921cf45-93af-400b-a9ed-0b85a194f812",
+      "name": "산미",
+      "imageUrl": ""
+    },
+    {
+      "id": "d2f64390-f36c-47b2-a787-46227a95ffc9",
+      "name": "고소",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-25"
+}

--- a/public/data/details/3456e613-742a-812f-8185-f5e79c36f5e6.json
+++ b/public/data/details/3456e613-742a-812f-8185-f5e79c36f5e6.json
@@ -1,0 +1,98 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-812f-8185-f5e79c36f5e6",
+    "reasonForSelection": "커피를 좋아하는 모든 사람들이 쉽고 편안하게 즐길 수 있는 커피 문화를 중심으로 성장 목표를 두고 있습니다. 커피 스니퍼에 방문하시는 분들이 역사 속에 담겨있는 커피 스니퍼를 시각적으로 즐길 수 있는 인테리어 포인트, 커피 중심의 메뉴 구성 등을 기반으로 어우러진 음악과 함께 오감을 만족시킬 수 있는 분위기를 조성합니다.",
+    "naverMapUrl": "https://naver.me/xFLuCc2K",
+    "name": "커피스니퍼 서울시청점",
+    "nearestStation": "시청",
+    "location": "서울 중구 세종대로16길 27 남양빌딩 1층 102호",
+    "price": 6800,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqG4Q9pfPVDTyNmQKTb0mLFHLDFSUGFLQUfshfnCA-hOyMJU5a3FNXoCURoydMXYqxfA5CjUHjDfp6R_gxew8xkGCdeWs5j_Yss=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "커피스니퍼 서울 시청점 (Koffee Sniffer Seoul City Hall)",
+        "uri": "https://maps.google.com/maps/contrib/105084200904133051989"
+      },
+      {
+        "displayName": "Josemaria Rafael Montemayor",
+        "uri": "https://maps.google.com/maps/contrib/105628346135126353482"
+      },
+      {
+        "displayName": "KunTa Tsai",
+        "uri": "https://maps.google.com/maps/contrib/114875921730523192845"
+      },
+      {
+        "displayName": "Анастасия Босько",
+        "uri": "https://maps.google.com/maps/contrib/109559085324617342384"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-812f-8185-f5e79c36f5e6-bean",
+    "description": "브라질 커피가 가지고 있는 균형 잡힌 향미와 함께 인도 로부스타 품종에서 느껴지는 구수함과 묵직한 바디감이 더해져 에스프레소 베리에이션 음료에 더할 나위 없이 잘 어울리는 커피입니다",
+    "name": "토스티 블렌드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "묵직한 바디",
+        "category": "Other"
+      },
+      {
+        "name": "다크 초콜릿",
+        "category": "Nutty/Cocoa"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "브라질",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "인도",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-812f-8185-f5e79c36f5e6-m1",
+      "name": "커스타드 라떼",
+      "price": 6800,
+      "imageUrl": "",
+      "description": "달콤한 커스터드 밀크 위에 에스페레소 크림이 올라간 음료"
+    },
+    {
+      "id": "3456e613-742a-812f-8185-f5e79c36f5e6-m2",
+      "name": "비스킷 라떼",
+      "price": 7000,
+      "imageUrl": "",
+      "description": "커피 비스킷 풍미가 가득한 우유와 에스프레소 크림의 조화"
+    }
+  ],
+  "tags": [
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    },
+    {
+      "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+      "name": "블렌드",
+      "imageUrl": ""
+    },
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+      "name": "라떼 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-27"
+}

--- a/public/data/details/3456e613-742a-8138-9e91-ed9e1a3863fc.json
+++ b/public/data/details/3456e613-742a-8138-9e91-ed9e1a3863fc.json
@@ -1,0 +1,97 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8138-9e91-ed9e1a3863fc",
+    "reasonForSelection": "알레그리아 커피 로스터스는 해 마다 갓 수확된 좋은 재료를 찾기 위하여 노력하며 커피가 가진 본연의 아름다움을 정확히 전달하기 위해 체계적인 로스팅 기법과 품질 검증 시스템을 갖춘 카페입니다.",
+    "naverMapUrl": "https://naver.me/xl0DvbDL",
+    "name": "알레그리아 광화문 케이스퀘어시티점",
+    "nearestStation": "광화문",
+    "location": "서울 중구 청계천로 24 1층",
+    "price": 6700,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqEh9OZOx1OceUcsEuQIUuFZc1Ow4oBmgBv0QlV0rLL8V0O-MPVeDYjGKEKHk5cOJnxs4htFl7QdLYPN2IL4slRyOgyOjwWVrEU=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "ACR • Alegria Coffee Roasters",
+        "uri": "https://maps.google.com/maps/contrib/113795254722403618287"
+      },
+      {
+        "displayName": "Supakij Khomvilai",
+        "uri": "https://maps.google.com/maps/contrib/109043515752937696097"
+      },
+      {
+        "displayName": "Lisa Nguyen-Maher",
+        "uri": "https://maps.google.com/maps/contrib/102654207693925420526"
+      },
+      {
+        "displayName": "ILSEOP LIM",
+        "uri": "https://maps.google.com/maps/contrib/106619759096815157789"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8138-9e91-ed9e1a3863fc-bean",
+    "description": "남녀노소 누구나 매일 마시기에 지루하지 않은 달콤하고 고소한 맛이 풍부한 커피입니다.첫 모금부터 입안에 남는 애프터까지 균형 잡힌 밸런스가 유지될 수 있도록 섬세하기 설계되어 있습니다.",
+    "name": "정글 에스프레소",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "묵직한 바디",
+        "category": "Other"
+      },
+      {
+        "name": "고소한",
+        "category": "Other"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "브라질",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "과테말라",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8138-9e91-ed9e1a3863fc-m1",
+      "name": "카페 라 노체",
+      "price": 6700,
+      "imageUrl": "",
+      "description": "정글 콜드브루를 베이스로 달콤한 콜드브루 밀크폼이 어우러진 알레그리아 시그니처 음료"
+    },
+    {
+      "id": "3456e613-742a-8138-9e91-ed9e1a3863fc-m2",
+      "name": "카페 콘 엘라도",
+      "price": 7000,
+      "imageUrl": "",
+      "description": "아이스 라떼 위에 바닐라 아이스크림이 올라가 달콤하게 마실 수 있는 아이스커피"
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+      "name": "블렌드",
+      "imageUrl": ""
+    },
+    {
+      "id": "c5c030e2-74f2-4031-bbfa-7573231b9121",
+      "name": "에스프레소 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-27"
+}

--- a/public/data/details/3456e613-742a-8147-8641-e38b38b62205.json
+++ b/public/data/details/3456e613-742a-8147-8641-e38b38b62205.json
@@ -1,0 +1,93 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8147-8641-e38b38b62205",
+    "reasonForSelection": "코리아 브루어스 컵 챔피언십(KBrC)를 비롯한 대회 수상자를 여럿 배출한 프릳츠는 국내 스페셜티 커피의 도입에 일조했습니다. 생두 바이어 김병기, 국가대표 챔피언 박근하를 비롯한 사람들이 모여 프릳츠를 설립했습니다. 대중적인 입맛을 사로잡은 블렌드를 선사합니다.",
+    "naverMapUrl": "https://naver.me/FzSZPU8k",
+    "name": "프릳츠 원서점",
+    "nearestStation": "안국",
+    "location": "서울 종로구 율곡로 83 아라리오 뮤지엄",
+    "price": 0,
+    "mainImageUrl": [
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240402_172%2F1712037942572gsrLk_JPEG%2F1.jpg"
+    ],
+    "imageAttributions": []
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8147-8641-e38b38b62205-bean",
+    "description": "커피는 과일이라는 슬로건 아래, 커피가 가진 고유한 밝은 산미와 깨끗한 단맛을 느낄 수 있습니다.",
+    "name": "서울 시네마",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "자두",
+        "category": "Fruity"
+      },
+      {
+        "name": "라즈베리",
+        "category": "Fruity"
+      },
+      {
+        "name": "레몬필",
+        "category": "Fruity"
+      },
+      {
+        "name": "아쌈티",
+        "category": "Floral"
+      },
+      {
+        "name": "설탕",
+        "category": "Sweet"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "코스타리카",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8147-8641-e38b38b62205-m1",
+      "name": "브루잉커피",
+      "price": 0,
+      "imageUrl": "https://ldb-phinf.pstatic.net/20220922_148/16638262488097T4m6_JPEG/%B5%B5%C8%AD%BA%EA%B7%E7%C0%D7.jpg",
+      "description": "원두의 풍미를 가장 잘 느낄 수 있는 브루잉 커피입니다."
+    },
+    {
+      "id": "3456e613-742a-8147-8641-e38b38b62205-m2",
+      "name": "카페라떼",
+      "price": 5000,
+      "imageUrl": "https://ldb-phinf.pstatic.net/20220922_291/1663826177655G8hRr_JPEG/%B6%F3%B6%BC.jpg",
+      "description": "에스프레소에 우유를 넣은 카페라테입니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+      "name": "대중적인",
+      "imageUrl": ""
+    },
+    {
+      "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+      "name": "블렌드",
+      "imageUrl": ""
+    },
+    {
+      "id": "0bf60d10-7f76-424f-97f3-4450ad284d73",
+      "name": "과일",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-28"
+}

--- a/public/data/details/3456e613-742a-814b-9c2b-e3e9a61d55db.json
+++ b/public/data/details/3456e613-742a-814b-9c2b-e3e9a61d55db.json
@@ -1,0 +1,95 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-814b-9c2b-e3e9a61d55db",
+    "reasonForSelection": "블루보틀은 오로지 커피 맛에 집중합니다. 국내 커피 접근성을 높이고 초심자에게 친절한 가이드를 건네는 블루보틀은 ‘2024년 탄소중립을 향한 우리의 로드맵’을 발표하는등 사회 영향을 강조합니다.",
+    "naverMapUrl": "https://naver.me/Fjbn5i6z",
+    "name": "블루보틀 홍대",
+    "nearestStation": "홍대입구",
+    "location": "서울 마포구 양화로 130 라이즈호텔 1층",
+    "price": 6600,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNvK4UkiWYztGWTEesgXSS1m6xM701GReDczssoBSsX4OuBrpvB5ZauF0OFxJ9aIoqWHEBO0zTyVfZ7rr6azqfElHOyCCC1PChRB_mVy343i2lm6wQsVvuTxmjqrA8LXkAnLDe-dJsmAYfr27kqj81VVA=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "chris kim",
+        "uri": "https://maps.google.com/maps/contrib/109918877500250771711"
+      },
+      {
+        "displayName": "Ed Uyeshima",
+        "uri": "https://maps.google.com/maps/contrib/117870220400430151038"
+      },
+      {
+        "displayName": "楊佳穎",
+        "uri": "https://maps.google.com/maps/contrib/100137338779577016130"
+      },
+      {
+        "displayName": "林小美",
+        "uri": "https://maps.google.com/maps/contrib/113048015410695794636"
+      },
+      {
+        "displayName": "水水",
+        "uri": "https://maps.google.com/maps/contrib/100338572678216552813"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-814b-9c2b-e3e9a61d55db-bean",
+    "description": "블루보틀 창립자인 제임스 프리먼이 개발한 블렌드입니다. 가장 깊고 진하며, 커피 로스팅 시간을 길게 하면 묵직한 바디감을 유지하면서도 강렬한 풍미와 최고의 단맛을 구현할 수 있습니다",
+    "name": "헤이즈 벨리 에스프레소",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "베이킹 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "오렌지필",
+        "category": "Fruity"
+      },
+      {
+        "name": "당밀",
+        "category": "Sweet"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "과테말라",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "브라질",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "DARK"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-814b-9c2b-e3e9a61d55db-m1",
+      "name": "놀라",
+      "price": 6600,
+      "imageUrl": "",
+      "description": "놀라는 블루보틀의 시그니처로, 뉴올리언스 스타일 라떼입니다. 다크 로스팅한 스페셜티 커피에 유기농 설탕과 우유를 배합했습니다."
+    },
+    {
+      "id": "3456e613-742a-814b-9c2b-e3e9a61d55db-m2",
+      "name": "싱글 오리진 (드립)",
+      "price": 6500,
+      "imageUrl": "",
+      "description": "싱글오리진 원두를 드립커피로 제공합니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-27"
+}

--- a/public/data/details/3456e613-742a-8154-afb6-d508a5bb3d47.json
+++ b/public/data/details/3456e613-742a-8154-afb6-d508a5bb3d47.json
@@ -1,0 +1,94 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8154-afb6-d508a5bb3d47",
+    "reasonForSelection": "국내 스페셜티 커피 1호인 커피리브레는 대한민국 최초의 커피 품질 감별사인 서필훈 큐그레이더가 이끄는 스페셜티 커피 브랜드입니다. 니콰과라의 핀카 리브레 농장을 운영합니다. 직접 운영하는 농장에서 재배해 신선한 싱글 오리진을 경험하실 수 있습니다.",
+    "naverMapUrl": "https://naver.me/I55aNfXZ",
+    "name": "커피리브레 명동성당점",
+    "nearestStation": "을지로3가",
+    "location": "서울 중구 명동길 74 명동성당",
+    "price": 5000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGWpUdkX0HYEVtbM45bFI1nv0xi0tx1RYm56C_04VKwmTYQByWjQCDHFqzrVKSkw5BEQaVGhH1TqMxVQ1Fk1q_z04ZDUIkB-x8=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "커피 리브레 명동성당점",
+        "uri": "https://maps.google.com/maps/contrib/114189357670439873721"
+      },
+      {
+        "displayName": "byung jung lee",
+        "uri": "https://maps.google.com/maps/contrib/111097757597410979602"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8154-afb6-d508a5bb3d47-bean",
+    "description": "골드문트는 독일어로 ‘황금입술’이라고 합니다. 최고급 라인업으로 분류되는 이 커피는 게이샤 품종으로, 풍부한 향과 깔끔한 맛을 특징으로 합니다.",
+    "name": "[골드문트] 콜롬비아 나리뇨 라 레이나 벨렌 게이샤",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "자스민",
+        "category": "Floral"
+      },
+      {
+        "name": "패션후르츠",
+        "category": "Fruity"
+      },
+      {
+        "name": "오렌지 블라썸",
+        "category": "Floral"
+      },
+      {
+        "name": "블루베리",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8154-afb6-d508a5bb3d47-m1",
+      "name": "싱글오리진",
+      "price": 5000,
+      "imageUrl": "",
+      "description": "싱글오리진 원두로 내리는 드립커피입니다."
+    },
+    {
+      "id": "3456e613-742a-8154-afb6-d508a5bb3d47-m2",
+      "name": "에스프레소",
+      "price": 4500,
+      "imageUrl": "",
+      "description": "에스프레소 머신으로 추출한 커피입니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    },
+    {
+      "id": "0bf60d10-7f76-424f-97f3-4450ad284d73",
+      "name": "과일",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-28"
+}

--- a/public/data/details/3456e613-742a-8158-b139-d5dee62905dd.json
+++ b/public/data/details/3456e613-742a-8158-b139-d5dee62905dd.json
@@ -1,0 +1,89 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8158-b139-d5dee62905dd",
+    "reasonForSelection": "카페 이름 [인덴트]는 새로 시작하는 문단의 첫머리를 들여씀을 뜻하는 단어입니다. 이처럼 인덴트는 단순한 커피숍을 넘어 머물며 쉬어갈 수 있는 특별한 공간입니다. 직접 볶고 내린 스페셜티 커피와 약간의 읽을거리를 제공합니다.",
+    "naverMapUrl": "https://naver.me/G2EOjUCU",
+    "name": "인덴트커피룸",
+    "nearestStation": "망원",
+    "location": "서울 마포구 희우정로20길 15 1층",
+    "price": 6000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMr_c7bS_U5cIe8Raiv-ovMROHncOhtuivN5GThAmtPjXazAUpYNFZbg2UaNUw898di99RWdgl3lgio3Z-x8POaBeWCGzrJX6QuG2_vO7bpQl_pzNVSJMe5yriLvwjsEaw7KnASxn14xCIml3s=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "Newjin",
+        "uri": "https://maps.google.com/maps/contrib/105446364100325684675"
+      },
+      {
+        "displayName": "JINU YOUN",
+        "uri": "https://maps.google.com/maps/contrib/112925352849439490899"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8158-b139-d5dee62905dd-bean",
+    "description": "향긋, 고소, 달콤 쌉싸름한, 데일리로 즐기기 좋은 편안한 느낌의 하우스 블렌드입니다.",
+    "name": "인덴트 하우스 블렌드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "밀크 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "시트러스",
+        "category": "Fruity"
+      },
+      {
+        "name": "토피넛",
+        "category": "Nutty/Cocoa"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "브라질",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8158-b139-d5dee62905dd-m1",
+      "name": "브루잉",
+      "price": 6000,
+      "imageUrl": "",
+      "description": "세심하게 고른 원두로 직접 내리는 브루잉 커피."
+    },
+    {
+      "id": "3456e613-742a-8158-b139-d5dee62905dd-m2",
+      "name": "피스타치오 크림라테",
+      "price": 6500,
+      "imageUrl": "",
+      "description": "하우스블렌드 베이스에 피스타치오 페이스트가 들어간, 고소하고 달콤한 크림라테."
+    }
+  ],
+  "tags": [
+    {
+      "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+      "name": "블루리본",
+      "imageUrl": ""
+    },
+    {
+      "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+      "name": "블렌드",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-25"
+}

--- a/public/data/details/3456e613-742a-815b-90d7-ef91d85b98aa.json
+++ b/public/data/details/3456e613-742a-815b-90d7-ef91d85b98aa.json
@@ -1,0 +1,75 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-815b-90d7-ef91d85b98aa",
+    "reasonForSelection": "2016년에 시작된 스페셜티 로스터리로, KCRC 대회에서 준우승을 차지한 최철 로스터님이 운영하는 가게입니다.  ’malic‘은 ‘사과에서 추출한 산’을 의미하는 단어인데, 그래서인지 카페 로고에도 사과가 그려져 있습니다. 또한 로스팅 할 때 말릭산을 잘 표현하면 원두에서 사과 향미를 느낄 수 있다고 합니다.",
+    "naverMapUrl": "https://naver.me/5k7GG6XQ",
+    "name": "말릭커피",
+    "nearestStation": "홍대입구",
+    "location": "서울 마포구 와우산로29바길 20 반지층 카페 말릭",
+    "price": 6000,
+    "mainImageUrl": [
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240725_30%2F1721862842184CIHxq_JPEG%2FIMG_5388.jpeg"
+    ],
+    "imageAttributions": []
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-815b-90d7-ef91d85b98aa-bean",
+    "description": "새콤달콤 과일향의 풍성함이 느껴지는 커피. 전반적으로 라즈베리, 오렌지 껍질 등의 과일 향이 나고 부드럽고 단 클린한 커피입니다.",
+    "name": "프루티블렌드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "라즈베리",
+        "category": "Fruity"
+      },
+      {
+        "name": "오렌지 블라썸",
+        "category": "Floral"
+      },
+      {
+        "name": "복숭아",
+        "category": "Fruity"
+      },
+      {
+        "name": "꽃향기",
+        "category": "Floral"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-815b-90d7-ef91d85b98aa-m1",
+      "name": "너티크림라떼",
+      "price": 6000,
+      "imageUrl": "http://imagefarm.baemin.com/smartmenuimage/upload/image/2020/11/25/aHSYiyUD7_Oc709NAvoeCxHg5n0XxYBE-_P8HK6vdogKB3PETcPbA82xzKsbC2wm.jpg",
+      "description": "우유와 땅콩크림의 단짠조화"
+    },
+    {
+      "id": "3456e613-742a-815b-90d7-ef91d85b98aa-m2",
+      "name": "아인슈페너/비엔나",
+      "price": 5500,
+      "imageUrl": "http://imagefarm.baemin.com/smartmenuimage/upload/image/2020/11/25/aHSYiyUD7_Oc709NAvoeC4tLbOF6mOFzLQ8wm-pox_zg0-kViJKMOVLh_Ytmv1xQ.jpg",
+      "description": "아메리카노 위에 수제 크림이 올려진 메뉴"
+    }
+  ],
+  "tags": [
+    {
+      "id": "66002d49-d8f9-4119-99ef-c508ead21371",
+      "name": "KBrC 수상",
+      "imageUrl": ""
+    },
+    {
+      "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+      "name": "라떼 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-28"
+}

--- a/public/data/details/3456e613-742a-8166-b916-fc0d662dea42.json
+++ b/public/data/details/3456e613-742a-8166-b916-fc0d662dea42.json
@@ -1,0 +1,105 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8166-b916-fc0d662dea42",
+    "reasonForSelection": "히트커피로스터스 서교점은 홍대 인근 서교동에 위치한 로스터리 카페로, 다양한 원두와 전문적인 커피를 제공합니다. 이곳은 필터 커피와 에스프레소 메뉴가 주를 이룹니다.",
+    "naverMapUrl": "https://naver.me/G9r5qIyD",
+    "name": "히트커피로스터스 서교",
+    "nearestStation": "홍대입구",
+    "location": "서울 마포구 동교로 146 관양빌딩 1층 카페",
+    "price": 6500,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPDoub3urTpzKT3Dk-yR6ieyZxVA_MpYc-FXUH2vcrK9r5zvwgL63u0yo9HjBL98HFdNDSZfTLaziMjdiEClbfEbyAurQT9vyluQoh0JtU6-wK596VLu6EDbr9yHGOM0Di2TWnH3WtGoNAQ-mw=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "범코치의 일상",
+        "uri": "https://maps.google.com/maps/contrib/102409794197688162389"
+      },
+      {
+        "displayName": "LU Hsiao-Feng",
+        "uri": "https://maps.google.com/maps/contrib/108616330114328846983"
+      },
+      {
+        "displayName": "林保葭",
+        "uri": "https://maps.google.com/maps/contrib/114030786419627776320"
+      },
+      {
+        "displayName": "조호정",
+        "uri": "https://maps.google.com/maps/contrib/108838961495267256926"
+      },
+      {
+        "displayName": "Anchalee Chantaweaj",
+        "uri": "https://maps.google.com/maps/contrib/109978116388928054955"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8166-b916-fc0d662dea42-bean",
+    "description": "강배전으로 로스팅된 크랙시한 에스프레소 입니다. 깜깜해진 자정을 넘긴 밤하늘을 때론 낮보다도 감성적이고 자유롭고 시간을 보내기 좋습니다.",
+    "name": "에스프레소 미드나이트",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "다크 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "헤이즐넛",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "묵직한 바디",
+        "category": "Other"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "브라질 세라도",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "콜롬비아 우일라",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "인도네시아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "DARK"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8166-b916-fc0d662dea42-m1",
+      "name": "넛츠크림라떼",
+      "price": 6500,
+      "imageUrl": "",
+      "description": "고소한 곡물 베이스에 에스프레소, 아몬드 크림이 올라간 시그니쳐 크림커피 입니다"
+    },
+    {
+      "id": "3456e613-742a-8166-b916-fc0d662dea42-m2",
+      "name": "코코넛라떼",
+      "price": 5500,
+      "imageUrl": "",
+      "description": "코코넛 시럽과 바닐라아이스크림의 조합이 좋은 히트커피의 시그니쳐 베리에이션 커피음료 입니다"
+    }
+  ],
+  "tags": [
+    {
+      "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+      "name": "시그니처",
+      "imageUrl": ""
+    },
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+      "name": "라떼 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-28"
+}

--- a/public/data/details/3456e613-742a-8167-bbe7-c86d5dccf82f.json
+++ b/public/data/details/3456e613-742a-8167-bbe7-c86d5dccf82f.json
@@ -1,0 +1,96 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8167-bbe7-c86d5dccf82f",
+    "reasonForSelection": "인터네셔널 초콜릿 어워드와 아카데미 오브 초콜릿에서 수상한 실력파 카페로, 신선한 원두와 카카오를 매일 로스팅하여 깊이 있는 커피와 화학 첨가물 없는 빈투바 초콜릿을 함께 즐길 수 있는 특별한 공간입니다.",
+    "naverMapUrl": "https://naver.me/G0DXsJ2f",
+    "name": "로스팅마스터즈 본점",
+    "nearestStation": "홍대입구",
+    "location": "서울 마포구 동교로 129 1층 로스팅마스터즈",
+    "price": 5300,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGyGqDQbJb993TUV-2L7zwgt1aNVW20Xb2gp3-2bwBsLo3frLLaVSJZzKpZu_ZiZrWicVd67KSreXEV-XxYykQWVcm3jxQ0_n0=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "로스팅마스터즈 본점",
+        "uri": "https://maps.google.com/maps/contrib/104162441183739850239"
+      },
+      {
+        "displayName": "Yunhee Nam",
+        "uri": "https://maps.google.com/maps/contrib/100333863946239230211"
+      },
+      {
+        "displayName": "Non Non39 (のんのん)",
+        "uri": "https://maps.google.com/maps/contrib/115567437524978682644"
+      },
+      {
+        "displayName": "Masters Roasting",
+        "uri": "https://maps.google.com/maps/contrib/109745297181587940790"
+      },
+      {
+        "displayName": "IAKOV PAK",
+        "uri": "https://maps.google.com/maps/contrib/103868824186246336228"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8167-bbe7-c86d5dccf82f-bean",
+    "description": "고소하고 깊은 맛의 합정 원두와 과실향의 밝은 맛을 가진 상수 원두를 매일 필요한 양만큼 로스팅하여 항상 신선한 상태를 유지합니다",
+    "name": "합정 마이스터 블랜드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "고소한",
+        "category": "Other"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "브라질",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "과테말라",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "인도",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8167-bbe7-c86d5dccf82f-m1",
+      "name": "드립커피",
+      "price": 5300,
+      "imageUrl": "",
+      "description": "신선하게 로스팅된 원두로 추출한 깊은 풍미의 핸드드립 커피"
+    },
+    {
+      "id": "3456e613-742a-8167-bbe7-c86d5dccf82f-m2",
+      "name": "멜팅초코",
+      "price": 6000,
+      "imageUrl": "",
+      "description": "카카오 초콜릿이 70%나 들어가는 진한 맛의 프리미엄 초콜릿 음료"
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "e36cc3de-cfad-4eee-91b9-eb3d2c421113",
+      "name": "초콜릿",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-29"
+}

--- a/public/data/details/3456e613-742a-8168-a4f1-cc45f6b820d2.json
+++ b/public/data/details/3456e613-742a-8168-a4f1-cc45f6b820d2.json
@@ -1,0 +1,106 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8168-a4f1-cc45f6b820d2",
+    "reasonForSelection": "헤베커피를 이끄는 여성 임지영 바리스타는 코리아 브루어스 컵 챔피언십(KBrC)을 수상하며 커피 시장에서 증명받았습니다. 호불호 없는 로스팅과 고소함을 통해 입문자들도 스페셜티에 빠져들게끔 합니다. 헤베커피는 두유와 에스프레소를 기반으로 한 시그니처 라테를 제공합니다.",
+    "naverMapUrl": "https://naver.me/GJEShSln",
+    "name": "헤베커피",
+    "nearestStation": "충무로",
+    "location": "서울 중구 필동로 32 낙원빌딩 1층",
+    "price": 6000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNXconVpn4gyBNZ_PVV2ZrXWvl6vPqE8EDA3c99o9NQfvD6CziB6xznE2VgHCnfhp95ezCYUX4D8Z-Yhx_iA9Vi9Z0onZ3IbuRj03ae0nhHz8Lvhfmp5ISJdD4nA-0Jgu9ryzh6LjQV5o9rQg=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "Hyoshin “최효신” Choi",
+        "uri": "https://maps.google.com/maps/contrib/116837340461218774818"
+      },
+      {
+        "displayName": "Kyobin Koo",
+        "uri": "https://maps.google.com/maps/contrib/116967419047356431868"
+      },
+      {
+        "displayName": "Yongsuk Sung",
+        "uri": "https://maps.google.com/maps/contrib/108959025408836147813"
+      },
+      {
+        "displayName": "지나Gina",
+        "uri": "https://maps.google.com/maps/contrib/101192948603330846278"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8168-a4f1-cc45f6b820d2-bean",
+    "description": "클래식 블렌드의 목표는 누구나 호불호 없이 즐길 수 있는 커피를 만드는 데 있습니다. 다크 초콜릿의 진하고 묵직한 맛과 견과류의 고소함을 가지며, 텁텁하지 않아 깔끔하게 마실 수 있습니다.",
+    "name": "클래식 블렌드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "다크 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "구운 호두",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "흑설탕",
+        "category": "Sweet"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "브라질 세라도",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "콜롬비아 우일라",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "인도네시아 만델링",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "DARK"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8168-a4f1-cc45f6b820d2-m1",
+      "name": "헤베커피",
+      "price": 6000,
+      "imageUrl": "",
+      "description": "시그니처 음료. 고소한 두유 베이스에 에스프레소 샷과 달콤한 생크림의 조화!"
+    },
+    {
+      "id": "3456e613-742a-8168-a4f1-cc45f6b820d2-m2",
+      "name": "브루잉커피",
+      "price": 0,
+      "imageUrl": "",
+      "description": "시즌에 가장 맛있는 싱글 오리진 커피를 선별하여 소개합니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "66002d49-d8f9-4119-99ef-c508ead21371",
+      "name": "KBrC 수상",
+      "imageUrl": ""
+    },
+    {
+      "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+      "name": "블루리본",
+      "imageUrl": ""
+    },
+    {
+      "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+      "name": "대중적인",
+      "imageUrl": ""
+    },
+    {
+      "id": "d2f64390-f36c-47b2-a787-46227a95ffc9",
+      "name": "고소",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": null
+}

--- a/public/data/details/3456e613-742a-8169-99e7-f8434bb3c01d.json
+++ b/public/data/details/3456e613-742a-8169-99e7-f8434bb3c01d.json
@@ -1,0 +1,79 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8169-99e7-f8434bb3c01d",
+    "reasonForSelection": "'Playback'은 재생의 의미를 가지고 있습니다. 이름의 의미처럼 커피와 음악을 매개로 문화 전반에 걸친 다양한 활동들 재생해나가고, 그것들을 통해 스페셜티 커피를 보다 많은 사람들과 함께 나누고 싶다는 의도가 담긴 카페입니다. 풍성한 음악과 함께 스페셜티 커피를 즐기고 싶다면 방문해보세요.",
+    "naverMapUrl": "https://naver.me/5S90Yc2A",
+    "name": "플레이백",
+    "nearestStation": "충무로",
+    "location": "서울 중구 퇴계로48길 32 1층",
+    "price": 0,
+    "mainImageUrl": [],
+    "imageAttributions": []
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8169-99e7-f8434bb3c01d-bean",
+    "description": "신선한 빨간사과와 오렌지의 산미, 사탕수수의 달콤함과 캐러멜 같은 부드러운 바디감이 조화를 이루며, 클린하고 깔끔한 후미가 지속됩니다. 워시드 가공 방식 특유의 깨끗한 질감과 과테말라 안티구아 지역의 독특한 테루아를 그대로 담아낸 이 원두는 브루잉 커피는 물론, 에스프레소에서도 밝고 생동감 있는 풍미를 선사합니다.",
+    "name": "과테말라 엘 템픽스케 워시드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "살구",
+        "category": "Fruity"
+      },
+      {
+        "name": "사과",
+        "category": "Fruity"
+      },
+      {
+        "name": "오렌지",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "과테말라",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8169-99e7-f8434bb3c01d-m1",
+      "name": "필터커피 (변동)",
+      "price": 0,
+      "imageUrl": "",
+      "description": "원두 본연의 개성과 섬세한 풍미를 깨끗하게 즐기는 커피."
+    },
+    {
+      "id": "3456e613-742a-8169-99e7-f8434bb3c01d-m2",
+      "name": "마카다미아 크림",
+      "price": 6500,
+      "imageUrl": "",
+      "description": "에소프레소, 마카다미아 우유, 크림, 마카다미아. 고소한 마카다미아와 크림의 부드러움이 어우러진 리치한 커피."
+    }
+  ],
+  "tags": [
+    {
+      "id": "1ead9a26-ab24-4d5b-b046-4af8636f6b97",
+      "name": "매니아",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "0921cf45-93af-400b-a9ed-0b85a194f812",
+      "name": "산미",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-24"
+}

--- a/public/data/details/3456e613-742a-816b-901c-e41c2416734d.json
+++ b/public/data/details/3456e613-742a-816b-901c-e41c2416734d.json
@@ -1,0 +1,93 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-816b-901c-e41c2416734d",
+    "reasonForSelection": "매주 로스팅을 하고, 다양한 산지의 원두를 볶아서 드립 커피를 내리는 카페입니다. 계절에 어울리는 소다와 가벼운 칵테일도 준비되어 있습니다.",
+    "naverMapUrl": "https://naver.me/FK5vi2LB",
+    "name": "퀜치커피",
+    "nearestStation": "망원",
+    "location": "서울 마포구 동교로12안길 9 . 1층",
+    "price": 5000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqFPQuvDl30fQfYvO9k2QZUoroD9KYzrlZ3YUo22BGWleoVGH5z7H_9QWG8GLEGh_R_IMmwrv7us1vInVlWyctUP-kW4Vz_-fpQ=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "퀜치커피 Quench Coffee",
+        "uri": "https://maps.google.com/maps/contrib/102010754974686746855"
+      },
+      {
+        "displayName": "Ho Yoo",
+        "uri": "https://maps.google.com/maps/contrib/117890331081109595652"
+      },
+      {
+        "displayName": "올리브",
+        "uri": "https://maps.google.com/maps/contrib/102504129803958740366"
+      },
+      {
+        "displayName": "B K",
+        "uri": "https://maps.google.com/maps/contrib/102736215150568380319"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-816b-901c-e41c2416734d-bean",
+    "description": "화사한 산미가 혀 끝에 오래 남아 진한 풍미를 선사합니다.",
+    "name": "니콰라가 리틀 레드 라이딩 후드 내추럴",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "라즈베리",
+        "category": "Fruity"
+      },
+      {
+        "name": "체리",
+        "category": "Fruity"
+      },
+      {
+        "name": "메이플 시럽",
+        "category": "Sweet"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "니카라과",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-816b-901c-e41c2416734d-m1",
+      "name": "카푸치노",
+      "price": 5000,
+      "imageUrl": "",
+      "description": "부드럽고 퐁신한 카푸치노의 감동."
+    },
+    {
+      "id": "3456e613-742a-816b-901c-e41c2416734d-m2",
+      "name": "필터 커피",
+      "price": 6000,
+      "imageUrl": "",
+      "description": "신중히 고른 원두로 직접 내리는 핸드드립."
+    }
+  ],
+  "tags": [
+    {
+      "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+      "name": "라떼 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+      "name": "대중적인",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-25"
+}

--- a/public/data/details/3456e613-742a-8170-962e-d3f534d87546.json
+++ b/public/data/details/3456e613-742a-8170-962e-d3f534d87546.json
@@ -1,0 +1,102 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8170-962e-d3f534d87546",
+    "reasonForSelection": "커피의 수확부터 한 잔의 커피에 이르기까지, 수많은 과정을 거칩니다. 커피와 그 한 잔을 즐기는 사람이 전부인 공간. 펠트는 오직 커피만을 위한 과정에 집중하는 카페입니다. 매년 직접 산지를 방문하여 생두를 선별하고, 가장 절정의 맛을 담습니다.",
+    "naverMapUrl": "https://naver.me/Gctrkvw1",
+    "name": "펠트커피 광화문점",
+    "nearestStation": "광화문",
+    "location": "서울 종로구 종로3길 17 B2층",
+    "price": 4500,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZM4TiaZ1Up8pWG1c2N83yN1ilG6kC-cA6JrnswqIkkkt4DmisQgfeHBTZgctXhJ6ki-d8MPy5nWM07GQ8c9kzdCrhN2g85EHgmg85USaNa1b_kdN3-3yykEVvopKfIbSONlzCA8SjdacSMSA7uwhqNRKA=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "EJ l",
+        "uri": "https://maps.google.com/maps/contrib/105490286672075104016"
+      },
+      {
+        "displayName": "PBHQ",
+        "uri": "https://maps.google.com/maps/contrib/100748775284369640799"
+      },
+      {
+        "displayName": "규규",
+        "uri": "https://maps.google.com/maps/contrib/111064026983487537709"
+      },
+      {
+        "displayName": "siro75",
+        "uri": "https://maps.google.com/maps/contrib/117148674458184446110"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8170-962e-d3f534d87546-bean",
+    "description": "낮은 톤의 산미, 밀크초콜렛과 다크초콜렛을 넘나드는것 같은 묵직하고 달콤함이 돋보이는 에스프레소. 누구나 편하게 즐길수 있는 균형감 있는 커피.",
+    "name": "펠트 커피 클래식 에스프레소",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "밀크 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "다크 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "고소한",
+        "category": "Other"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "코스타리카",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "DARK"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8170-962e-d3f534d87546-m1",
+      "name": "에스프레소",
+      "price": 4500,
+      "imageUrl": "",
+      "description": "고온·고압의 추출 방식으로 커피의 진한 풍미와 크레마를 즐길 수 있는 커피"
+    },
+    {
+      "id": "3456e613-742a-8170-962e-d3f534d87546-m2",
+      "name": "브루드 커피",
+      "price": 6500,
+      "imageUrl": "",
+      "description": "뜨거운 물을 이용해 원두의 풍미를 우려내는 방식으로 추출된 커피."
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "0921cf45-93af-400b-a9ed-0b85a194f812",
+      "name": "산미",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-24"
+}

--- a/public/data/details/3456e613-742a-817c-b986-dcc0c7945e00.json
+++ b/public/data/details/3456e613-742a-817c-b986-dcc0c7945e00.json
@@ -1,0 +1,92 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-817c-b986-dcc0c7945e00",
+    "reasonForSelection": "2002년도에 시작한 테라로사는 강원도에 뿌리내린 브랜드입니다. 스페셜티 커피 브랜드를 표방하며 스페셜티 미식을 알리려는 선구자입니다. 농부명을 표기하고 공정무역을 추진하는 Picker Project에 임합니다.",
+    "naverMapUrl": "https://naver.me/FEUpAjIk",
+    "name": "테라로사 국립현대미술관서울점",
+    "nearestStation": "안국",
+    "location": "서울 종로구 삼청로 30 국립현대미술관 서울관 1층",
+    "price": 0,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOb0J7etstQ0AZL71MxwWcwFl2lEo08E1DkNxgfHTtu_Zw4vocVXtPA-aqLhXACDxDNUUxUFcMI9XwyLOBBaifeWXtruOw-olKbNGSHf8JS7Q4JV4UMBN9evuhNKCzGA5ezgVV1vBUTarBBgcaqGH09mA=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "이동현 (커넥터리)",
+        "uri": "https://maps.google.com/maps/contrib/117240882341854953168"
+      },
+      {
+        "displayName": "ADEN",
+        "uri": "https://maps.google.com/maps/contrib/101083200750962039989"
+      },
+      {
+        "displayName": "김경실",
+        "uri": "https://maps.google.com/maps/contrib/102967200202073535718"
+      },
+      {
+        "displayName": "MJ",
+        "uri": "https://maps.google.com/maps/contrib/112976572875988699111"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-817c-b986-dcc0c7945e00-bean",
+    "description": "핑크 부르봉은 최근 주목받고 있는 원두로, 레드와 옐로 부르봉이 자연 교배하여 만들어진 품종입니다. 실제로는 옅은 붉은빛입니다. 상큼한 오렌지와 크렌베리, 그리고 히비스커스의 향을 느낄 수 있습니다.",
+    "name": "콜롬비아 우일라 핑크 부르봉",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "오렌지",
+        "category": "Fruity"
+      },
+      {
+        "name": "히비스커스",
+        "category": "Floral"
+      },
+      {
+        "name": "크랜베리",
+        "category": "Fruity"
+      },
+      {
+        "name": "망고",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "콜롬비아 우일라",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-817c-b986-dcc0c7945e00-m1",
+      "name": "핸드드립",
+      "price": 0,
+      "imageUrl": "",
+      "description": "핸드드립 방식의 커피입니다."
+    },
+    {
+      "id": "3456e613-742a-817c-b986-dcc0c7945e00-m2",
+      "name": "실론 시나몬 라테",
+      "price": 6500,
+      "imageUrl": "",
+      "description": "쌉쌀한 시나몬이 들어가 은은히 달달한 라테입니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": null
+}

--- a/public/data/details/3456e613-742a-8182-960e-e41c0092839c.json
+++ b/public/data/details/3456e613-742a-8182-960e-e41c0092839c.json
@@ -1,0 +1,85 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8182-960e-e41c0092839c",
+    "reasonForSelection": "2013년부터 커피를 사랑하는 사람들에게 가이드 역할을 해오고 있는 빈브라더스는 한국을 넘어서서 활동하는 커피 전문가 집단입니다. 빈브라더스는 저가형 커피 브랜드들과 경쟁하는 것이 아니기에, 탁월한 품질의 커피를 만드는 일과 훌륭한 커피 경험의 전달에 대부분의 역량을 집중합니다.",
+    "naverMapUrl": "https://naver.me/5JpUFf2L",
+    "name": "빈브라더스 합정",
+    "nearestStation": "합정",
+    "location": "서울 마포구 토정로 35-1",
+    "price": 7000,
+    "mainImageUrl": [
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230531_262%2F1685542994202MxNal_JPEG%2F%25B3%25BB%25BA%25CE01.jpg"
+    ],
+    "imageAttributions": []
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8182-960e-e41c0092839c-bean",
+    "description": "기본에 충실한 블랙 타입 음료에 최적화된 커피. 초콜릿의 달콤함과 구운 견과의 고소함이 조화롭고, 단맛의 여운이 길게 이어집니다.",
+    "name": "블랙수트",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "밀크 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "구운 호두",
+        "category": "Nutty/Cocoa"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "브라질",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8182-960e-e41c0092839c-m1",
+      "name": "드립커피",
+      "price": 7000,
+      "imageUrl": "https://ldb-phinf.pstatic.net/20230531_101/1685524957088kaOdb_JPEG/%B5%E5%B8%B3%C4%BF%C7%C7_ICED.jpg",
+      "description": "원두에 따라 가격이 달라집니다"
+    },
+    {
+      "id": "3456e613-742a-8182-960e-e41c0092839c-m2",
+      "name": "화이트 스파이스 라떼",
+      "price": 6500,
+      "imageUrl": "https://ldb-phinf.pstatic.net/20250212_55/1739343932180Fhq3V_JPEG/DSCF3637.jpg",
+      "description": "카다멈과 생강, 시나몬 등으로 만든 시럽을 더한 라떼"
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+      "name": "블렌드",
+      "imageUrl": ""
+    },
+    {
+      "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+      "name": "시그니처",
+      "imageUrl": ""
+    },
+    {
+      "id": "45507d6d-9817-4f8c-a23b-2f119d9101d2",
+      "name": "드립커피",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-28"
+}

--- a/public/data/details/3456e613-742a-8184-94c5-f50be5356e64.json
+++ b/public/data/details/3456e613-742a-8184-94c5-f50be5356e64.json
@@ -1,0 +1,89 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8184-94c5-f50be5356e64",
+    "reasonForSelection": "망원지튼은 스페셜티 커피와 잘 어울리는 다양한 베이커리를 직접 만드는 공간입니다. 에스프레소와 브루드 커피를 제공하며, 브루드 커피는 시즌별로 원두가 달라집니다. 베이커리는 케이크, 까눌레, 타르트 3종류를 취급하며, 매일 매장에서 직접 구워 신선한 맛을 제공합니다.",
+    "naverMapUrl": "https://naver.me/GvcQC2fn",
+    "name": "망원 지튼",
+    "nearestStation": "망원",
+    "location": "서울 마포구 망원로 73 2층 ZTTN",
+    "price": 6000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqHU69RXln7bbG3wQTiv9jHFLjaPq-oCH5G2g4Pup7KWOqDQgqb4_H5h_VBhE11ECYe4tIB1FAFVkFj-XaDG4R3IIFfMSnQRFak=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "망원 지튼",
+        "uri": "https://maps.google.com/maps/contrib/104684183525583287497"
+      },
+      {
+        "displayName": "박정환",
+        "uri": "https://maps.google.com/maps/contrib/100988524057110604884"
+      },
+      {
+        "displayName": "장유민",
+        "uri": "https://maps.google.com/maps/contrib/109618683476606217821"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8184-94c5-f50be5356e64-bean",
+    "description": "땅콩, 호두의 고소한 향과 다크 초콜릿의 중후한 향이 어우러지는 원두입니다. 스모키하고 달콤쌉싸름한 맛이 특징입니다.",
+    "name": "과테말라 후에후에테낭고",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "땅콩",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "호두",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "다크 초콜릿",
+        "category": "Nutty/Cocoa"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "과테말라",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "DARK"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8184-94c5-f50be5356e64-m1",
+      "name": "Brewed Coffee",
+      "price": 6000,
+      "imageUrl": "",
+      "description": "계절에 따라 직접 골라 제공되는 커피."
+    },
+    {
+      "id": "3456e613-742a-8184-94c5-f50be5356e64-m2",
+      "name": "God Father",
+      "price": 6000,
+      "imageUrl": "",
+      "description": "12시간 침출된 콜드브루와 수제바닐라크림의 조화."
+    }
+  ],
+  "tags": [
+    {
+      "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+      "name": "대중적인",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+      "name": "시그니처",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-25"
+}

--- a/public/data/details/3456e613-742a-8189-b998-eaeabad432e2.json
+++ b/public/data/details/3456e613-742a-8189-b998-eaeabad432e2.json
@@ -1,0 +1,98 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8189-b998-eaeabad432e2",
+    "reasonForSelection": "국내 스페셜티 커피 1호인 커피리브레는 대한민국 최초의 커피 품질 감별사인 서필훈 큐그레이더가 이끄는 스페셜티 커피 브랜드입니다. 니콰과라의 핀카 리브레 농장을 운영합니다. 직접 운영하는 농장에서 재배해 신선한 싱글 오리진을 경험하실 수 있습니다.",
+    "naverMapUrl": "https://naver.me/5yPnkiTI",
+    "name": "커피리브레 연남점",
+    "nearestStation": "홍대입구",
+    "location": "서울 마포구 성미산로32길 20-5",
+    "price": 5000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGMMEHOipREJd-v-hrxQf0O99vcnnlsoiBChHLi2aMApVzPZf-GR_QZu7Gp6lg7g151J7BOo--BaPfmIMvIQXW_ver_VG60SbM=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "커피 리브레 연남점",
+        "uri": "https://maps.google.com/maps/contrib/100188394623092256534"
+      },
+      {
+        "displayName": "CY S",
+        "uri": "https://maps.google.com/maps/contrib/100734868837257853242"
+      },
+      {
+        "displayName": "jang ramul",
+        "uri": "https://maps.google.com/maps/contrib/103608043953656784658"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8189-b998-eaeabad432e2-bean",
+    "description": "골드문트는 독일어로 ‘황금입술’이라고 합니다. 최고급 라인업으로 분류되는 이 커피는 게이샤 품종으로, 풍부한 향과 깔끔한 맛을 특징으로 합니다.",
+    "name": "[골드문트] 콜롬비아 나리뇨 라 레이나 벨렌 게이샤",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "자스민",
+        "category": "Floral"
+      },
+      {
+        "name": "패션후르츠",
+        "category": "Fruity"
+      },
+      {
+        "name": "오렌지 블라썸",
+        "category": "Floral"
+      },
+      {
+        "name": "블루베리",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8189-b998-eaeabad432e2-m1",
+      "name": "싱글오리진",
+      "price": 5000,
+      "imageUrl": "",
+      "description": "싱글오리진 원두로 내리는 드립커피입니다."
+    },
+    {
+      "id": "3456e613-742a-8189-b998-eaeabad432e2-m2",
+      "name": "에스프레소",
+      "price": 4500,
+      "imageUrl": "",
+      "description": "에스프레소 머신으로 추출한 커피입니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    },
+    {
+      "id": "0bf60d10-7f76-424f-97f3-4450ad284d73",
+      "name": "과일",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-29"
+}

--- a/public/data/details/3456e613-742a-818e-a791-ec118760640d.json
+++ b/public/data/details/3456e613-742a-818e-a791-ec118760640d.json
@@ -1,0 +1,85 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-818e-a791-ec118760640d",
+    "reasonForSelection": "리사르커피는 에스프레소에 집중한 독특한 경험과 고급스러운 분위기로 많은 사람들에게 매력을 줍니다. 스탠딩 바 형태로 빠른 회전율을 자랑하며, 바쁜 현대인에게 적합한 형태입니다.이러한 요인들이 리사르커피를 인기 있는 커피 장소로 만드는 데 기여하고 있습니다",
+    "naverMapUrl": "https://naver.me/IxsqtPB2",
+    "name": "리사르커피 종로점",
+    "nearestStation": "광화문",
+    "location": "서울 종로구 종로5길 7 1층",
+    "price": 1500,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZM5RvPTtATC0dwVeDWV4jZYhfeiyu4EwCVqNTIycTZLU04_vxi4i1OzN5zfgD6NdHMC3Uy6IZ47bh6qecY_4Vz8hO15I9w8rlZb-itnbhDcZt2CuLbXY80klpuMLOQy7GWfDd0MWk6dYPNwEuQ=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "kang kang",
+        "uri": "https://maps.google.com/maps/contrib/107641118937651317189"
+      },
+      {
+        "displayName": "Leesar Coffee Jongno 리사르커피 종로",
+        "uri": "https://maps.google.com/maps/contrib/111421352271308849915"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-818e-a791-ec118760640d-bean",
+    "description": "하우스블렌드 다크는 리사르커피의 경험을 가득 담아 만든 좋은 품질의 원두커피 입니다. 초코렛스럽고 견과류같은 향기가 나며 고전적인 무게감과 은은하고 그윽한 산미를 가지고 있습니다. 쌉사름한 맛이 나며 다른 맛들은 조화롭게 어우러져 부드럽고 목넘김이 편합니다.",
+    "name": "하우스 블렌드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "다크 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "땅콩",
+        "category": "Nutty/Cocoa"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "브라질",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "DARK"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-818e-a791-ec118760640d-m1",
+      "name": "카페 에스프레소",
+      "price": 1500,
+      "imageUrl": "",
+      "description": "리사르 커피의 기본 커피"
+    },
+    {
+      "id": "3456e613-742a-818e-a791-ec118760640d-m2",
+      "name": "카페 피에노",
+      "price": 2500,
+      "imageUrl": "",
+      "description": "에스프레소와 크림,카카오 토핑"
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+      "name": "블렌드",
+      "imageUrl": ""
+    },
+    {
+      "id": "c5c030e2-74f2-4031-bbfa-7573231b9121",
+      "name": "에스프레소 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-28"
+}

--- a/public/data/details/3456e613-742a-8192-aec1-d19b274b78b9.json
+++ b/public/data/details/3456e613-742a-8192-aec1-d19b274b78b9.json
@@ -1,0 +1,96 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8192-aec1-d19b274b78b9",
+    "reasonForSelection": "스몰토크를 좋아하는 사장님은 지역사회에 따뜻한 온기를 불어넣습니다. 스피드스터 커피머신과 이쪼 발키리를 사용하며. 게이샤의 맛을 알리는데 일조합니다.",
+    "naverMapUrl": "https://naver.me/5FmSoaLH",
+    "name": "텐스퀘어 남산",
+    "nearestStation": "회현",
+    "location": "서울 중구 소월로 33 1층",
+    "price": 0,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqEy68BzN32eUUyD2vQ2YKiTuc8bA-9ARBt-j6UV6e3JAfnxSV8-jfPyIRBomNOC0xZfKxUkpz9u8iWbVk9177uA-DxKpXuVWkI=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "10스퀘어 남산",
+        "uri": "https://maps.google.com/maps/contrib/100160772982925886311"
+      },
+      {
+        "displayName": "G S",
+        "uri": "https://maps.google.com/maps/contrib/114414547499468359326"
+      },
+      {
+        "displayName": "J Park",
+        "uri": "https://maps.google.com/maps/contrib/105302015867721389336"
+      },
+      {
+        "displayName": "大村優介",
+        "uri": "https://maps.google.com/maps/contrib/117318016048129172153"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8192-aec1-d19b274b78b9-bean",
+    "description": "게이샤는 아라비카 품종 중 하나로, 대중들에게 각광받는 품종 중 하나입니다. 풍부한 향과 깔끔한 맛으로 널리 알려져 있습니다.",
+    "name": "게이샤 블렌드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "캐모마일",
+        "category": "Floral"
+      },
+      {
+        "name": "자스민",
+        "category": "Floral"
+      },
+      {
+        "name": "베리",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "페루",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "과테말라",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8192-aec1-d19b274b78b9-m1",
+      "name": "시그니처 아이스 아메리카노",
+      "price": 0,
+      "imageUrl": "",
+      "description": "샤인머스켓, 자몽, 화이트와인의 과일 특유의 맛이 도드라지는 커피입니다."
+    },
+    {
+      "id": "3456e613-742a-8192-aec1-d19b274b78b9-m2",
+      "name": "게이샤라떼",
+      "price": 9500,
+      "imageUrl": "",
+      "description": "1000잔 이상 팔린 명실상부 시그니처입니다. 페루,콜롬비아 그리고 과테말라의 게이샤 품종을 들여와 라떼로 만들었습니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "1ead9a26-ab24-4d5b-b046-4af8636f6b97",
+      "name": "매니아",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": null
+}

--- a/public/data/details/3456e613-742a-8198-bb10-d841006daf57.json
+++ b/public/data/details/3456e613-742a-8198-bb10-d841006daf57.json
@@ -1,0 +1,73 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-8198-bb10-d841006daf57",
+    "reasonForSelection": "노띵커피는 Seed to Cup 정신으로 투명한 원두 과정을 소비자에게 전달하는 데 일조합니다. 2018 코리아 브루어스 컵 챔피언십(KBrC) 6위 수상의 김현화 바리스타를 배출할 뿐만 아니라, 2년 연속 블루리본을 받았습니다. 싱글오리진 라인업을 마실 수 있습니다.",
+    "naverMapUrl": "https://naver.me/FvEtHhXa",
+    "name": "노띵커피 본점",
+    "nearestStation": "동대입구",
+    "location": "서울 중구 서소문로 89-20 1동 1층 103호",
+    "price": 3500,
+    "mainImageUrl": [],
+    "imageAttributions": []
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-8198-bb10-d841006daf57-bean",
+    "description": "허니 프로세싱 커피는 워시드 커피보다는 산미가 약하고 복합적인 향미를 가집니다. 또한 허니라는 이름에 어울리게 흑설탕과 꿀처럼 은은한 단맛도 느낄 수 있습니다.",
+    "name": "브룬디 마샤 허니",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "붉은 베리류",
+        "category": "Fruity"
+      },
+      {
+        "name": "살구",
+        "category": "Fruity"
+      },
+      {
+        "name": "캐모마일",
+        "category": "Floral"
+      },
+      {
+        "name": "꿀",
+        "category": "Sweet"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "브룬디",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-8198-bb10-d841006daf57-m1",
+      "name": "드립커피(노띵배러)",
+      "price": 3500,
+      "imageUrl": "",
+      "description": "스페셜티 배치브루 커피"
+    },
+    {
+      "id": "3456e613-742a-8198-bb10-d841006daf57-m2",
+      "name": "벨벳라떼",
+      "price": 4000,
+      "imageUrl": "",
+      "description": "스페셜티 카페라떼입니다. 벨벳처럼 부드러운 촉감의 거품이 올라갑니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+      "name": "블루리본",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": null
+}

--- a/public/data/details/3456e613-742a-819b-93ff-c4e48531760e.json
+++ b/public/data/details/3456e613-742a-819b-93ff-c4e48531760e.json
@@ -1,0 +1,92 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-819b-93ff-c4e48531760e",
+    "reasonForSelection": "을지로와 충무로 일대에 카페를 둔 섹터커피 로스터스는 직장인의 점심시간을 채울 수 있는 공간을 꿈꾸며 대중적인 입맛을 사로잡았습니다. 우유 기반 음료가 대표적이며, '좋은 사람들'이라는 장애 단체에 8년째 나눔하는 선한 영향력을 행사합니다.",
+    "naverMapUrl": "https://naver.me/5jJTMeSH",
+    "name": "섹터커피로스터스 본점",
+    "nearestStation": "충무로",
+    "location": "서울 중구 퇴계로36길 35 1층 섹터 커피 로스터스 본점",
+    "price": 4000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOe7IBy25Y9LS2R6ecttPbvDAXIz9mN9gErwTqCnPQAfiIjXklqMcYLUtMDhIPHRNLv1oqTQLLxSDHJRWPzLnKUUFRFym1v25s6Ew0TyP-8tfhfYgI9Cooapws00ph0zGooCjDrake_uV1v=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "jihyon bae",
+        "uri": "https://maps.google.com/maps/contrib/112992327282736445583"
+      },
+      {
+        "displayName": "짱이야",
+        "uri": "https://maps.google.com/maps/contrib/114699963417588940889"
+      },
+      {
+        "displayName": "Tomas G",
+        "uri": "https://maps.google.com/maps/contrib/100489612856131015301"
+      },
+      {
+        "displayName": "Kyuwon Lee",
+        "uri": "https://maps.google.com/maps/contrib/110778779454043925617"
+      },
+      {
+        "displayName": "Pichanun Boonpromgul",
+        "uri": "https://maps.google.com/maps/contrib/118145485622453747582"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-819b-93ff-c4e48531760e-bean",
+    "description": "황설탕의 단맛과 과일의 상큼함이 모두 돋보이는 원두입니다. 아프리카 최대의 커피 생산지인 에티오피아의 풍부한 향을 느낄 수 있습니다.",
+    "name": "블랜딩",
+    "engName": "UTTER",
+    "flavors": [
+      {
+        "name": "흑설탕",
+        "category": "Sweet"
+      },
+      {
+        "name": "라즈베리",
+        "category": "Fruity"
+      },
+      {
+        "name": "체리",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-819b-93ff-c4e48531760e-m1",
+      "name": "FLAT WHITE",
+      "price": 4000,
+      "imageUrl": "",
+      "description": "플랫화이트는 우유 거품이 평평하게 들어가서 플랫(Flat) 화이트라고 부릅니다. 라테보다 짙어 에스프레소의 맛이 더욱 느껴지는 커피입니다."
+    },
+    {
+      "id": "3456e613-742a-819b-93ff-c4e48531760e-m2",
+      "name": "스위트 카푸치노",
+      "price": 4500,
+      "imageUrl": "",
+      "description": "스위트 카푸치노는 라테 위에 시나몬을 뿌려 달콤한 카푸치노와도 같은 부드러운 맛을 느낄 수 있습니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+      "name": "대중적인",
+      "imageUrl": ""
+    },
+    {
+      "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+      "name": "라떼 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": null
+}

--- a/public/data/details/3456e613-742a-819d-87b0-cb05eaed1ce5.json
+++ b/public/data/details/3456e613-742a-819d-87b0-cb05eaed1ce5.json
@@ -1,0 +1,95 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-819d-87b0-cb05eaed1ce5",
+    "reasonForSelection": "블루보틀은 오로지 커피 맛에 집중합니다. 국내 커피 접근성을 높이고 초심자에게 친절한 가이드를 건네는 블루보틀은 ‘2024년 탄소중립을 향한 우리의 로드맵’을 발표하는등 사회 영향을 강조합니다.",
+    "naverMapUrl": "https://naver.me/xVBx9fpO",
+    "name": "블루보틀 광화문 카페",
+    "nearestStation": "광화문",
+    "location": "서울 종로구 청계천로 11 1층",
+    "price": 6600,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMu4EcMAUPJv9kNTxt3k9VPcE3xw9YhfaQJJMlNI6T1bQC0WM7Ie6MOXObEMono6gGWg2s36en44SbSY8WNiaN0pldW7LKcIPpArGX8RcQJmRjgV0uaFPOxU1EM8s0DWiNLR6NwbHpyVeKLysM=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "Minki Jeon",
+        "uri": "https://maps.google.com/maps/contrib/117682195379940907161"
+      },
+      {
+        "displayName": "rosenie",
+        "uri": "https://maps.google.com/maps/contrib/107541774454123623996"
+      },
+      {
+        "displayName": "PBHQ",
+        "uri": "https://maps.google.com/maps/contrib/100748775284369640799"
+      },
+      {
+        "displayName": "김혜정",
+        "uri": "https://maps.google.com/maps/contrib/116873594925716763421"
+      },
+      {
+        "displayName": "juju1 1117",
+        "uri": "https://maps.google.com/maps/contrib/115193856539822311490"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-819d-87b0-cb05eaed1ce5-bean",
+    "description": "블루보틀 창립자인 제임스 프리먼이 개발한 블렌드입니다. 가장 깊고 진하며, 커피 로스팅 시간을 길게 하면 묵직한 바디감을 유지하면서도 강렬한 풍미와 최고의 단맛을 구현할 수 있습니다",
+    "name": "헤이즈 벨리 에스프레소",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "베이킹 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "오렌지필",
+        "category": "Fruity"
+      },
+      {
+        "name": "당밀",
+        "category": "Sweet"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "과테말라",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "브라질",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "DARK"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-819d-87b0-cb05eaed1ce5-m1",
+      "name": "놀라",
+      "price": 6600,
+      "imageUrl": "",
+      "description": "놀라는 블루보틀의 시그니처로, 뉴올리언스 스타일 라떼입니다. 다크 로스팅한 스페셜티 커피에 유기농 설탕과 우유를 배합했습니다."
+    },
+    {
+      "id": "3456e613-742a-819d-87b0-cb05eaed1ce5-m2",
+      "name": "싱글 오리진 (드립)",
+      "price": 6500,
+      "imageUrl": "",
+      "description": "싱글오리진 원두를 드립커피로 제공합니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-27"
+}

--- a/public/data/details/3456e613-742a-81a4-a35a-cfc0bd4c8aec.json
+++ b/public/data/details/3456e613-742a-81a4-a35a-cfc0bd4c8aec.json
@@ -1,0 +1,98 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81a4-a35a-cfc0bd4c8aec",
+    "reasonForSelection": "커피그래는 3년 연속 블루리본을 받았습니다. 폭 넓은 원두 선택으로 부담없는 커피 여정의 시작이 될 수 있습니다. 싱글 오리진으로 산미가 돋보이는 필터커피를 입문하기 좋습니다.",
+    "naverMapUrl": "https://naver.me/I55ajFRF",
+    "name": "커피그래",
+    "nearestStation": "약수",
+    "location": "서울 중구 동호로 204 1층",
+    "price": 0,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO-KO_p-yiiYdw4fXxXp9MR3Fu_nSvQNv6vr2wFyKisy8ct_ZFGuTvp_HFuCruSVwC37c69hh5Zt7tvDDp6XNZmdDcYM0hffXFmfemktjELbF4uo5uCPZKo0_ngtBJGRHPM8Xg3CN13V8omPNY=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "stepanorama",
+        "uri": "https://maps.google.com/maps/contrib/101365978953489823828"
+      },
+      {
+        "displayName": "Yeonju Im",
+        "uri": "https://maps.google.com/maps/contrib/105073872421360972186"
+      },
+      {
+        "displayName": "Vivian Chen",
+        "uri": "https://maps.google.com/maps/contrib/113780243021424332188"
+      },
+      {
+        "displayName": "이동현 (커넥터리)",
+        "uri": "https://maps.google.com/maps/contrib/117240882341854953168"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81a4-a35a-cfc0bd4c8aec-bean",
+    "description": "커피 원두의 국가대표 결정전이라고도 볼 수 있는 Cup of Excellence 대회에서 우수한 성적을 가진 온두라스의 원두입니다. 밝게 볶아서 꽃향기와 백도/청포도의 상큼한 맛을 느낄 수 있습니다. 따뜻한 커피로 마시면 좋습니다.",
+    "name": "온두라스 5위 버지니아스 게이샤 워시드",
+    "engName": "CoE",
+    "flavors": [
+      {
+        "name": "꽃향기",
+        "category": "Floral"
+      },
+      {
+        "name": "백도",
+        "category": "Fruity"
+      },
+      {
+        "name": "청포도",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "온두라스",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81a4-a35a-cfc0bd4c8aec-m1",
+      "name": "핸드드립",
+      "price": 0,
+      "imageUrl": "",
+      "description": "커피의 맛을 가장 많이 느낄 수 있는 추출 방식입니다."
+    },
+    {
+      "id": "3456e613-742a-81a4-a35a-cfc0bd4c8aec-m2",
+      "name": "카페라떼",
+      "price": 5500,
+      "imageUrl": "",
+      "description": "카페라떼입니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+      "name": "블루리본",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    },
+    {
+      "id": "a43f33e2-31f1-47dd-b479-2b60e7d50c26",
+      "name": "꽃향기",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": null
+}

--- a/public/data/details/3456e613-742a-81aa-870b-e8492d89a078.json
+++ b/public/data/details/3456e613-742a-81aa-870b-e8492d89a078.json
@@ -1,0 +1,85 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81aa-870b-e8492d89a078",
+    "reasonForSelection": "로스터가 직접 운영하는 망원동 로스터리 카페 루틸입니다. 다양한 스페셜티 커피를 매일 로스팅하고 있으며 핸드드립으로 맛보실 수 있습니다. 커피 외에도 루틸에서만 경험하실 수 있는 시그니처 음료들이 준비돼 있습니다.",
+    "naverMapUrl": "https://naver.me/55rAjnJk",
+    "name": "루틸",
+    "nearestStation": "망원",
+    "location": "서울 마포구 포은로 136 1층 루틸",
+    "price": 5000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMcOxLjdPHPLcUHBAnpOzLQYTUvnHK2JV5yZw9TqvX0Qrj1oeDCk6YOZsrG_7DukG6dGB9paKWrpWrKXkZ4JUc75cmGAmF0RlXKCNhLgjB7r9WkRjS8c_qtMMAT3GxhuW6YEWJJf2BSDsnGgtXy7jQs=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "유영상",
+        "uri": "https://maps.google.com/maps/contrib/117446042587647161743"
+      },
+      {
+        "displayName": "Rutile",
+        "uri": "https://maps.google.com/maps/contrib/105257275143129772496"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81aa-870b-e8492d89a078-bean",
+    "description": "시트러스의 산미가 있으면서도 밀크 초콜릿의 고소하고 달콤한 향미가 중심을 잘 잡아주는 원두입니다.",
+    "name": "코스타리카 로스 앙헬레스 돈 카이토",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "오렌지",
+        "category": "Fruity"
+      },
+      {
+        "name": "복숭아",
+        "category": "Fruity"
+      },
+      {
+        "name": "밀크 초콜릿",
+        "category": "Nutty/Cocoa"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "코스타리카",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81aa-870b-e8492d89a078-m1",
+      "name": "핸드드립",
+      "price": 5000,
+      "imageUrl": "",
+      "description": "직접 고르고 로스팅한 원두를 내려드리는 핸드드립."
+    },
+    {
+      "id": "3456e613-742a-81aa-870b-e8492d89a078-m2",
+      "name": "카페 라떼",
+      "price": 4300,
+      "imageUrl": "",
+      "description": "밸런스가 훌륭한 카페 라떼."
+    }
+  ],
+  "tags": [
+    {
+      "id": "1ead9a26-ab24-4d5b-b046-4af8636f6b97",
+      "name": "매니아",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-25"
+}

--- a/public/data/details/3456e613-742a-81ac-99c2-d659d9f5c674.json
+++ b/public/data/details/3456e613-742a-81ac-99c2-d659d9f5c674.json
@@ -1,0 +1,77 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81ac-99c2-d659d9f5c674",
+    "reasonForSelection": "'탁월한 커피전문가 집단'인 빈브라더스의 매장 중 하나입니다. 바리스타의 이름을 표기하며 존중하는 모습이 돋보입니다. 고품질의 싱글오리진 원두를 맛보실 수 있습니다. 과일향이 돋보이는 원두로 맛있는 산미를 느낄 수 있는 쉽지않은 기회입니다.",
+    "naverMapUrl": "https://naver.me/FsRslsi1",
+    "name": "결",
+    "nearestStation": "광화문",
+    "location": "서울 종로구 공평동 17",
+    "price": 0,
+    "mainImageUrl": [
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20231211_85%2F1702260626377lmDSt_JPEG%2F%25B0%25E1_1.jpg"
+    ],
+    "imageAttributions": []
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81ac-99c2-d659d9f5c674-bean",
+    "description": "좋은 케냐 커피는 기본적으로 흑설탕처럼 진득하게 달콤한 향이 납니다. 망고와 샤인 머스캣부터 자두와 파인애플, 오렌지까지, 주의를 기울이면 진한 달콤함의 베이스 위 풍부한 과일 향을 느낄 수 있습니다.",
+    "name": "케냐 기투구",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "자몽",
+        "category": "Fruity"
+      },
+      {
+        "name": "오렌지",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "케냐",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81ac-99c2-d659d9f5c674-m1",
+      "name": "필터 커피",
+      "price": 0,
+      "imageUrl": "https://ldb-phinf.pstatic.net/20230531_283/1685525917846LOV6w_JPEG/%B5%E5%B8%B3%C4%BF%C7%C7_ICED_%281%29.jpg",
+      "description": "필터로 내린 커피입니다."
+    },
+    {
+      "id": "3456e613-742a-81ac-99c2-d659d9f5c674-m2",
+      "name": "바닐라라떼",
+      "price": 0,
+      "imageUrl": "https://ldb-phinf.pstatic.net/20230531_242/1685526003844vkJ34_JPEG/%B6%F3%B6%BC%B9%D9%B4%D2%B6%F3_ICED.jpg",
+      "description": "에스프레소에 우유를 넣고 바닐라 향을 가미해 달달한 라테입니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    },
+    {
+      "id": "0bf60d10-7f76-424f-97f3-4450ad284d73",
+      "name": "과일",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-28"
+}

--- a/public/data/details/3456e613-742a-81b3-a1ba-c4fdfeb25956.json
+++ b/public/data/details/3456e613-742a-81b3-a1ba-c4fdfeb25956.json
@@ -1,0 +1,92 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81b3-a1ba-c4fdfeb25956",
+    "reasonForSelection": "벌새는 핸드드립 전문점으로, 진하게 내린 드립 커피와 우유에 소량의 설탕을 넣어 달달한 버터 스카치 캔디 맛 구현합니다. ‘커피가게동경’크루에서 오랫동안 일 했던 류형준 바리스타가 로스팅한 원두들을 기본으로 판매합니다.",
+    "naverMapUrl": "https://naver.me/FJbWAuE4",
+    "name": "벌새",
+    "nearestStation": "광화문",
+    "location": "서울 종로구 새문안로3길 12 신문로빌딩 지하 1층 22,23호",
+    "price": 6500,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGdqlkD2as_qw73O_SeO84iAxT_A6Xr03On7UiWjssW35N1Jio0j-UoocPSKPwI1WyHJlfLWU3RyVkyb6yH4Ybb5keVGXc2uEU=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "벌새",
+        "uri": "https://maps.google.com/maps/contrib/117605988042720754281"
+      },
+      {
+        "displayName": "Newjin",
+        "uri": "https://maps.google.com/maps/contrib/105446364100325684675"
+      },
+      {
+        "displayName": "siro75",
+        "uri": "https://maps.google.com/maps/contrib/117148674458184446110"
+      },
+      {
+        "displayName": "アオヤマアオヤマ",
+        "uri": "https://maps.google.com/maps/contrib/101123761628381978757"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81b3-a1ba-c4fdfeb25956-bean",
+    "description": "고급스러운 맛과 향을 가진 품종으로, 특히 화려한 꽃향과 과일 향이 특징입니다.",
+    "name": "페루 라팔마 게이샤 워시드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "꿀",
+        "category": "Sweet"
+      },
+      {
+        "name": "꽃향기",
+        "category": "Floral"
+      },
+      {
+        "name": "슈퍼클린",
+        "category": "Sour/Fermented"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "페루",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81b3-a1ba-c4fdfeb25956-m1",
+      "name": "비엔나 커피",
+      "price": 6500,
+      "imageUrl": "",
+      "description": "크림의 부드러움과 아메리카노의 씁쓸한 맛, 시간이 지났을 때 생기는 단맛이 어우러져 커피입니다."
+    },
+    {
+      "id": "3456e613-742a-81b3-a1ba-c4fdfeb25956-m2",
+      "name": "카페오레",
+      "price": 6500,
+      "imageUrl": "",
+      "description": "프랑스에서 프렌치 프레스로 내린 커피와 우유를 같은 비율로, 기호에 따라 설탕을 약간 넣어 마시는 음료입니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "1ead9a26-ab24-4d5b-b046-4af8636f6b97",
+      "name": "매니아",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-23"
+}

--- a/public/data/details/3456e613-742a-81b4-903d-ea20420b9a3f.json
+++ b/public/data/details/3456e613-742a-81b4-903d-ea20420b9a3f.json
@@ -1,0 +1,93 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81b4-903d-ea20420b9a3f",
+    "reasonForSelection": "커피친구는 다양한 원두를 직접 볶고 정성스럽게 내린 핸드드립 커피를 제공하는 전문점입니다. 이곳은 세월이 묻어나는 인테리어와 다양한 커피 기구들이 마치 교토의 한 커피숍에 온 듯한 전통적인 분위기를 자아냅니다.",
+    "naverMapUrl": "https://naver.me/GoDXU61B",
+    "name": "커피친구",
+    "nearestStation": "종각",
+    "location": "서울 종로구 삼봉로 81 두산위브파빌리온",
+    "price": 6000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN62RQ1FnwvGKUmwr2fz9oqNtG5yj66k2NZPOdDAfxP3dr1j2xdu5liLLeGrienmwhFgRoKNbE9YMKCVFJagsN-12bdWsGIZjc96rL-UtLkgbWD1XSds3DArBnFPi0HEFpKJqnb4wCYh8qji9k=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "De La",
+        "uri": "https://maps.google.com/maps/contrib/106119554221740690788"
+      },
+      {
+        "displayName": "Tanuja Bhat",
+        "uri": "https://maps.google.com/maps/contrib/114150979507454066144"
+      },
+      {
+        "displayName": "Jackie H Lim",
+        "uri": "https://maps.google.com/maps/contrib/104350919687035955949"
+      },
+      {
+        "displayName": "eofish",
+        "uri": "https://maps.google.com/maps/contrib/111441020920432035855"
+      },
+      {
+        "displayName": "un promeneur solitaire",
+        "uri": "https://maps.google.com/maps/contrib/100309870201186518618"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81b4-903d-ea20420b9a3f-bean",
+    "description": "고유한 향미와 풍미를 제공하여 커피 애호가들에게 큰 매력을 줍니다. 자연 건조와 세척 처리 방법에 따라 와인 같은 맛이나 레몬그라스와 자스민 같은 향미를 경험할 수 있습니다.",
+    "name": "에티오피아 이르가체페",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "꽃향기",
+        "category": "Floral"
+      },
+      {
+        "name": "시트러스",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81b4-903d-ea20420b9a3f-m1",
+      "name": "에티오피아",
+      "price": 6000,
+      "imageUrl": "",
+      "description": "에티오피아에서 생산되는 커피 중 가장 세련된 커피로 평가되며 풍부한 향미와 깨끗한 신맛, 부드러운 단맛이 특징인 고급 커피입니다."
+    },
+    {
+      "id": "3456e613-742a-81b4-903d-ea20420b9a3f-m2",
+      "name": "모카 마타리",
+      "price": 9000,
+      "imageUrl": "",
+      "description": "세계에서 최고의 커피중 하나로 평가받고 있으며 와인과 같은 풍미와 깔금하고 오래 지속되는 뒷맛으로 커피의 귀부인이라고도 불립니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    },
+    {
+      "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+      "name": "블루리본",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-27"
+}

--- a/public/data/details/3456e613-742a-81ba-832d-c748b394872e.json
+++ b/public/data/details/3456e613-742a-81ba-832d-c748b394872e.json
@@ -1,0 +1,83 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81ba-832d-c748b394872e",
+    "reasonForSelection": "노띵커피는 Seed to Cup 정신으로 투명한 원두 과정을 소비자에게 전달하는 데 일조합니다. 2018 코리아 브루어스 컵 챔피언십(KBrC) 6위 수상의 김현화 바리스타를 배출할 뿐만 아니라, 2년 연속 블루리본을 받았습니다. 싱글오리진 라인업을 마실 수 있습니다.",
+    "naverMapUrl": "https://naver.me/FvEtHhXa",
+    "name": "노띵커피 시청점",
+    "nearestStation": "시청",
+    "location": "서울 중구 서소문로 89-20 1동 1층 103호",
+    "price": 3500,
+    "mainImageUrl": [],
+    "imageAttributions": []
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81ba-832d-c748b394872e-bean",
+    "description": "허니 프로세싱 커피는 워시드 커피보다는 산미가 약하고 복합적인 향미를 가집니다. 또한 허니라는 이름에 어울리게 흑설탕과 꿀처럼 은은한 단맛도 느낄 수 있습니다.",
+    "name": "부룬디 마샤 허니",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "붉은 베리류",
+        "category": "Fruity"
+      },
+      {
+        "name": "살구",
+        "category": "Fruity"
+      },
+      {
+        "name": "캐모마일",
+        "category": "Floral"
+      },
+      {
+        "name": "꿀",
+        "category": "Sweet"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "브룬디",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81ba-832d-c748b394872e-m1",
+      "name": "드립커피(노띵배러)",
+      "price": 3500,
+      "imageUrl": "",
+      "description": "스페셜티 배치브루 커피"
+    },
+    {
+      "id": "3456e613-742a-81ba-832d-c748b394872e-m2",
+      "name": "벨벳라떼",
+      "price": 4000,
+      "imageUrl": "",
+      "description": "스페셜티 카페라떼입니다. 벨벳처럼 부드러운 촉감의 거품이 올라갑니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+      "name": "블루리본",
+      "imageUrl": ""
+    },
+    {
+      "id": "66002d49-d8f9-4119-99ef-c508ead21371",
+      "name": "KBrC 수상",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": null
+}

--- a/public/data/details/3456e613-742a-81c3-b6ef-fdf02f2327f3.json
+++ b/public/data/details/3456e613-742a-81c3-b6ef-fdf02f2327f3.json
@@ -1,0 +1,101 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81c3-b6ef-fdf02f2327f3",
+    "reasonForSelection": "출판사였던 곳을 펄시커피라는 이름으로 창출해낸 구조적 아름다움, 그리고 이 공간을 지켜온 오랜 시간과 가치들을 녹여낸 커피가 어우러져 있습니다. 펄시가 전하는 맛과 향, 그리고 시간은 새로운 기억을 고스란히 저장하는 펄시만의 기록입니다. 펄시커피의 모든 커피에는 매년 sca에서 엄선한 스페셜티 원두만을 사용하고 있습니다.",
+    "naverMapUrl": "https://naver.me/5uIYkv3v",
+    "name": "펄시커피",
+    "nearestStation": "동대입구",
+    "location": "서울 중구 동호로20길 34-57 1층 펄시커피",
+    "price": 5800,
+    "mainImageUrl": [
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240901_205%2F1725157605724m0bUr_PNG%2F%25C6%25DE%25BD%25C3%25C4%25BF%25C7%25C7_%25BF%25DC%25BA%25CE1.png"
+    ],
+    "imageAttributions": []
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81c3-b6ef-fdf02f2327f3-bean",
+    "description": "펄시커피에서 가장 사랑받고 즐겨찾는 블랜드 스텔라입니다. 복합적인 베리 뉘앙스에 복숭아, 자두의 새콤달콤함을 더했으며 플로럴함과 와이니함을 함께 갖고 있는 게 특징입니다. 스텔라는 마지막 한 방울의 맛까지 오래 기억되는 고유의 블렌드 커피입니다.",
+    "name": "스텔라 블랜드 커피",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "레드와인",
+        "category": "Sour/Fermented"
+      },
+      {
+        "name": "자두",
+        "category": "Fruity"
+      },
+      {
+        "name": "시나몬",
+        "category": "Spices"
+      },
+      {
+        "name": "블루베리",
+        "category": "Fruity"
+      },
+      {
+        "name": "꽃향기",
+        "category": "Floral"
+      },
+      {
+        "name": "복숭아",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "케냐",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81c3-b6ef-fdf02f2327f3-m1",
+      "name": "SIGNATURE BROWN",
+      "price": 5800,
+      "imageUrl": "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20241120_35%2F1732094179717gRbtR_PNG%2FIMG_3796.png",
+      "description": "(ONLY ICE) 유기농 우유와 스페셜티 에스프레소가 진하게 어우러진 플랫화이트 위로 시나몬 크림과 에스프레소의 글레이징 조화가 환상적인 미소가 절로 지어 지는 맛입니다.8온스의 음료로 펄시의 컬러를 가장 잘 보여주는 작지만 강렬한 맛의 커피 입니다."
+    },
+    {
+      "id": "3456e613-742a-81c3-b6ef-fdf02f2327f3-m2",
+      "name": "STELLA B:LATTE",
+      "price": 6000,
+      "imageUrl": "",
+      "description": "(ONLY ICE) STELLA BLEND로 만든 체리초콜릿 맛 아이스 라떼입니다. *호불호 갈리는 메뉴입니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+      "name": "시그니처",
+      "imageUrl": ""
+    },
+    {
+      "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+      "name": "블렌드",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    },
+    {
+      "id": "45507d6d-9817-4f8c-a23b-2f119d9101d2",
+      "name": "드립커피",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-27"
+}

--- a/public/data/details/3456e613-742a-81cf-99c5-c3dd1135f656.json
+++ b/public/data/details/3456e613-742a-81cf-99c5-c3dd1135f656.json
@@ -1,0 +1,95 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81cf-99c5-c3dd1135f656",
+    "reasonForSelection": "블루보틀은 오로지 커피 맛에 집중합니다. 국내 커피 접근성을 높이고 초심자에게 친절한 가이드를 건네는 블루보틀은‘ 2024년 탄소중립을 향한 우리의 로드맵’을 발표하는등 사회 영향을 강조합니다.",
+    "naverMapUrl": "https://naver.me/FafyiH32",
+    "name": "블루보틀 삼청 카페",
+    "nearestStation": "안국",
+    "location": "서울 종로구 북촌로5길 76",
+    "price": 6600,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNkjHFR2a7_qMc0XiZI_4iR5qDTNQvU0pUELbQQkyyHSPBqwrmcw7gq41Fc7l2Y4wd6h4mNu5Zs1qwS-NuUa9iAGHH46LAlN-lyV_-HeOlu_GbR3lQ--5eDYSFIVMZVq8HYdAH2w2ANPlwhLtK6TgobZw=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "루나루이",
+        "uri": "https://maps.google.com/maps/contrib/102265699602969609145"
+      },
+      {
+        "displayName": "HA KWON",
+        "uri": "https://maps.google.com/maps/contrib/109161350980383316858"
+      },
+      {
+        "displayName": "WenHuei Chen",
+        "uri": "https://maps.google.com/maps/contrib/111271951369724601076"
+      },
+      {
+        "displayName": "HUN KIM",
+        "uri": "https://maps.google.com/maps/contrib/104490842568215655362"
+      },
+      {
+        "displayName": "Eon Wang",
+        "uri": "https://maps.google.com/maps/contrib/104092365072111774209"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81cf-99c5-c3dd1135f656-bean",
+    "description": "블루보틀 창립자인 제임스 프리먼이 개발한 블렌드입니다. 가장 깊고 진하며, 커피 로스팅 시간을 길게 하면 묵직한 바디감을 유지하면서도 강렬한 풍미와 최고의 단맛을 구현할 수 있습니다",
+    "name": "헤이즈 벨리 에스프레소",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "베이킹 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "오렌지필",
+        "category": "Fruity"
+      },
+      {
+        "name": "당밀",
+        "category": "Sweet"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "과테말라",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "브라질",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "DARK"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81cf-99c5-c3dd1135f656-m1",
+      "name": "놀라",
+      "price": 6600,
+      "imageUrl": "",
+      "description": "놀라는 블루보틀의 시그니처로, 뉴올리언스 스타일 라떼입니다. 다크 로스팅한 스페셜티 커피에 유기농 설탕과 우유를 배합했습니다."
+    },
+    {
+      "id": "3456e613-742a-81cf-99c5-c3dd1135f656-m2",
+      "name": "싱글오리진 (드립)",
+      "price": 6500,
+      "imageUrl": "",
+      "description": "싱글오리진 원두를 드립커피로 제공합니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-27"
+}

--- a/public/data/details/3456e613-742a-81d3-ba40-cb1b75933052.json
+++ b/public/data/details/3456e613-742a-81d3-ba40-cb1b75933052.json
@@ -1,0 +1,93 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81d3-ba40-cb1b75933052",
+    "reasonForSelection": "드립커피 전문점으로, 우유와 함께 잘 녹지 않은 오독오독 씹히는 설탕 인 “보현 라떼”를 주력으로 소비자들에게 인기를 끌고 있습니다.",
+    "naverMapUrl": "https://naver.me/5XJy0lfu",
+    "name": "보현커피",
+    "nearestStation": "동대입구",
+    "location": "서울 중구 동호로30길 31 1층",
+    "price": 4000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqEZpwb53dht3D7erbmyf6aXHOApAhnrqNGDQ4eBcRcJEe-PcgNo1mo_QknJxFRcG84x0F4jDeL7TekdTzcJqy7TIVL2kaesSWM=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "보현커피 (BO HYUN Coffee)",
+        "uri": "https://maps.google.com/maps/contrib/101825584993305805085"
+      },
+      {
+        "displayName": "Yong Chung",
+        "uri": "https://maps.google.com/maps/contrib/110930874229939308722"
+      },
+      {
+        "displayName": "Thomas Borch",
+        "uri": "https://maps.google.com/maps/contrib/105452752025181778492"
+      },
+      {
+        "displayName": "BEE KIM",
+        "uri": "https://maps.google.com/maps/contrib/106683935268746501914"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81d3-ba40-cb1b75933052-bean",
+    "description": "게이샤 원두는 긴 타원형의 모양을 가지고 있으며, 향미가 복잡하고 섬세합니다. 게이샤 블렌드는 이러한 게이샤 원두의 특성을 유지하면서도 다른 원두와의 조화를 통해 균형 잡힌 맛을 제공합니다.",
+    "name": "게이샤 블렌드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "자스민",
+        "category": "Floral"
+      },
+      {
+        "name": "과일",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "페루",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "콜롬비아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81d3-ba40-cb1b75933052-m1",
+      "name": "보현카페라떼",
+      "price": 4000,
+      "imageUrl": "",
+      "description": "커피우유,잘 녹지않고 오독오독 씹히는 설탕"
+    },
+    {
+      "id": "3456e613-742a-81d3-ba40-cb1b75933052-m2",
+      "name": "추천 드립 커피",
+      "price": 5000,
+      "imageUrl": "",
+      "description": "원두의 아로마와 맛에 기준을 둔 스페셜 티"
+    }
+  ],
+  "tags": [
+    {
+      "id": "1ead9a26-ab24-4d5b-b046-4af8636f6b97",
+      "name": "매니아",
+      "imageUrl": ""
+    },
+    {
+      "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+      "name": "시그니처",
+      "imageUrl": ""
+    },
+    {
+      "id": "45507d6d-9817-4f8c-a23b-2f119d9101d2",
+      "name": "드립커피",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-28"
+}

--- a/public/data/details/3456e613-742a-81d7-b08d-dda44d80c230.json
+++ b/public/data/details/3456e613-742a-81d7-b08d-dda44d80c230.json
@@ -1,0 +1,94 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81d7-b08d-dda44d80c230",
+    "reasonForSelection": "편안한 분위기와 디저트와 스페셜티를 페어링해서",
+    "naverMapUrl": "https://naver.me/GWe2U9By",
+    "name": "포트레이트커피바",
+    "nearestStation": "망원",
+    "location": "서울 마포구 포은로8길 32 1층",
+    "price": 0,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqHV0ZB0vrL1_RJtdlrDo7rqgZOTHgDWa0yOPKDmIpMDnJ_CcM-BEYE4Dz7Em1iV6R6HtWiVbz6gwsRLfCjqY8tkiwfr7W2Url4=s4800-w555"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "Portrait coffeebar",
+        "uri": "https://maps.google.com/maps/contrib/117655452661769370578"
+      },
+      {
+        "displayName": "Holideez",
+        "uri": "https://maps.google.com/maps/contrib/100869257863584612957"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81d7-b08d-dda44d80c230-bean",
+    "description": "에티오피아 PG1 에이미 내추럴은 최고급 생두로 각광받았습니다.G1 등급을 뛰어넘어서 그렇게 해석함.",
+    "name": "에티오피아 에이미 네추럴",
+    "engName": "PG1",
+    "flavors": [
+      {
+        "name": "라즈베리",
+        "category": "Fruity"
+      },
+      {
+        "name": "체리",
+        "category": "Fruity"
+      },
+      {
+        "name": "열대과일",
+        "category": "Fruity"
+      },
+      {
+        "name": "쥬시",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81d7-b08d-dda44d80c230-m1",
+      "name": "브루잉",
+      "price": 0,
+      "imageUrl": "",
+      "description": "가격 변동"
+    },
+    {
+      "id": "3456e613-742a-81d7-b08d-dda44d80c230-m2",
+      "name": "헤비 화이트",
+      "price": 5500,
+      "imageUrl": "",
+      "description": "부드럽다 독특하다"
+    }
+  ],
+  "tags": [
+    {
+      "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+      "name": "대중적인",
+      "imageUrl": ""
+    },
+    {
+      "id": "0921cf45-93af-400b-a9ed-0b85a194f812",
+      "name": "산미",
+      "imageUrl": ""
+    },
+    {
+      "id": "84e16f3f-5d1b-49e4-83d9-d38a3349f840",
+      "name": "필터 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+      "name": "시그니처",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": null
+}

--- a/public/data/details/3456e613-742a-81e5-8e15-f523eaff7d4a.json
+++ b/public/data/details/3456e613-742a-81e5-8e15-f523eaff7d4a.json
@@ -1,0 +1,77 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81e5-8e15-f523eaff7d4a",
+    "reasonForSelection": "업사이 커피는 특별함보단 익숙함에 가치를잡고 운영하는 커피 브랜드입니다.  강아지 심볼만큼이나 친숙한 커피를 만들고자합니다.",
+    "naverMapUrl": "https://naver.me/x2jAtNPn",
+    "name": "업사이드커피 약수점",
+    "nearestStation": "약수",
+    "location": "서울 중구 동호로10길 42 1층",
+    "price": 5000,
+    "mainImageUrl": [
+      "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230629_8%2F1688001957512bTny5_JPEG%2FIMG_1839.jpeg"
+    ],
+    "imageAttributions": []
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81e5-8e15-f523eaff7d4a-bean",
+    "description": "대중적이고 하루에 한 잔 먹기 좋은 스페셜티 입문용 원두",
+    "name": "에티오피아 아리차(Aricha) 내추럴",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "과일",
+        "category": "Fruity"
+      },
+      {
+        "name": "꽃향기",
+        "category": "Floral"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "에티오피아",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "DARK"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81e5-8e15-f523eaff7d4a-m1",
+      "name": "해방촌커피",
+      "price": 5000,
+      "imageUrl": "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240528_138%2F1716859832976ssjuR_JPEG%2FIMG_2483.jpeg",
+      "description": "크림+플랫화이트"
+    },
+    {
+      "id": "3456e613-742a-81e5-8e15-f523eaff7d4a-m2",
+      "name": "약수에 바나나",
+      "price": 5000,
+      "imageUrl": "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240528_48%2F1716859832359RpYbq_JPEG%2FIMG_3858.jpeg",
+      "description": "바나나시럽+크림+플랫화이트"
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+      "name": "대중적인",
+      "imageUrl": ""
+    },
+    {
+      "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+      "name": "라떼 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+      "name": "시그니처",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-27"
+}

--- a/public/data/details/3456e613-742a-81e7-a47a-e5cda7abe514.json
+++ b/public/data/details/3456e613-742a-81e7-a47a-e5cda7abe514.json
@@ -1,0 +1,110 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81e7-a47a-e5cda7abe514",
+    "reasonForSelection": "2009년에 출범한 챔프커피는 5호점까지 운영하는 한국의 터줏대감입니다. 카페를 운영할 뿐만 아니라, 원두를 직접 볶고 납품합니다. 직관적인 맛과 다양한 원두 선택지로 대중적인 입맛을 사로잡을 수 있는 우유 기반의 커피 종류가 잘 엄선되어 있습니다.",
+    "naverMapUrl": "https://naver.me/57VZ8Tpk",
+    "name": "챔프커피 제3작업실",
+    "nearestStation": "을지로3가",
+    "location": "서울 중구 을지로 157 라열 3층 381호",
+    "price": 5000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNWvpgkp3KX_oXfgqKz91fYJjxRh16VQbXO5sxnGjaJZQ4E7aU_y5mCS1_OF0yumd1q1WIkE4YYoZamvkAic0dacJKvwMqlcUddKxh5VIaGQu5bj5czJoU9XlriWFOclrrSj5f8QYnqi8MP288P1aJ20g=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "Troy Nam",
+        "uri": "https://maps.google.com/maps/contrib/109077213121368193973"
+      },
+      {
+        "displayName": "시래캔",
+        "uri": "https://maps.google.com/maps/contrib/113330853258777970160"
+      },
+      {
+        "displayName": "Lu pin",
+        "uri": "https://maps.google.com/maps/contrib/103191946365919722161"
+      },
+      {
+        "displayName": "小不點Paine",
+        "uri": "https://maps.google.com/maps/contrib/115521204432315046152"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81e7-a47a-e5cda7abe514-bean",
+    "description": "강배전의 장점을 살린 챔프커피의 대표 블렌드입니다. 무게감과 단맛을 두루 갖춰 고소하며 산미에 민감한 사람들이 쉽게 마실 수 있습니다.",
+    "name": "알리 블렌드",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "묵직한 바디",
+        "category": "Other"
+      },
+      {
+        "name": "다크 초콜릿",
+        "category": "Nutty/Cocoa"
+      },
+      {
+        "name": "호두",
+        "category": "Nutty/Cocoa"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "과테말라 안티구아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "케냐",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "인도네시아",
+        "flagImageUrl": ""
+      },
+      {
+        "name": "인도",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "DARK"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81e7-a47a-e5cda7abe514-m1",
+      "name": "챔프커피",
+      "price": 5000,
+      "imageUrl": "",
+      "description": "라떼보다 작은 사이즈의 진하고 고소한 커피입니다."
+    },
+    {
+      "id": "3456e613-742a-81e7-a47a-e5cda7abe514-m2",
+      "name": "리스트레토",
+      "price": 4800,
+      "imageUrl": "",
+      "description": "24g의 원두를 사용해서 에스프레소보다 짧게 추출된 커피입니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "b20b1b80-50ce-49a4-8ef2-ee2d58b8e4fe",
+      "name": "브랜드",
+      "imageUrl": ""
+    },
+    {
+      "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+      "name": "대중적인",
+      "imageUrl": ""
+    },
+    {
+      "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+      "name": "라떼 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "d0d0bdb1-e7c7-4671-96b1-1f3e8c2d745c",
+      "name": "블렌드",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": null
+}

--- a/public/data/details/3456e613-742a-81ec-a7e8-fc3e1001a29e.json
+++ b/public/data/details/3456e613-742a-81ec-a7e8-fc3e1001a29e.json
@@ -1,0 +1,102 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81ec-a7e8-fc3e1001a29e",
+    "reasonForSelection": "블루보틀의 헤드 로스터로 일했던 맥컬리 커피의 대표는 을지로에서 유니크한 미국 분위기를 뽐냅니다. CoE(Cup of Execllence) 원두를 취급하는 등 더 맛있는 원두를 친근하게 제공하고자 합니다. 핸드드립부터 라테까지 올라운더의 역할을 톡톡히 해내고 있습니다.",
+    "naverMapUrl": "https://naver.me/FqWt3kDL",
+    "name": "맥컬리커피",
+    "nearestStation": "을지로3가",
+    "location": "서울 중구 충무로5길 6-1 2층",
+    "price": 4800,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqFnO3ToAZInMXVimYPISzXs0lO6lx9SqA2xAVu52Hw1lJ2V6V8tlENT1bbdS8bpmI69WbUuVyfVCsWtkEJ_2XmZFMkcksFZkOc=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "맥컬리커피",
+        "uri": "https://maps.google.com/maps/contrib/112776837295624220563"
+      },
+      {
+        "displayName": "Winnie Lee",
+        "uri": "https://maps.google.com/maps/contrib/103607488160778828911"
+      },
+      {
+        "displayName": "Janine Pagtakhan",
+        "uri": "https://maps.google.com/maps/contrib/102432335726703941796"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81ec-a7e8-fc3e1001a29e-bean",
+    "description": "Jamison이 운영 중인 Deborah 농장의 커피는 국내외 바리스타와 브루어스컵 대회에서 수많은 타이틀을 획득했습니다. 2017년월드브루어스컵에서 2위, 월드바리스타챔피언십에서 5위, 보스턴 WBC에서 2위와 4위를 차지했습니다. 와인 산업에서 수십 년간 사용된 공정방법인 Carboric Maceration를 커피에 접목한 세계 최초의 기업 중 하나입니다.",
+    "name": "파나마 핀카 데보라 일루미네션 게이샤",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "블러드 오렌지",
+        "category": "Fruity"
+      },
+      {
+        "name": "히비스커스",
+        "category": "Floral"
+      },
+      {
+        "name": "로스 와인 베르가못",
+        "category": "Fruity"
+      },
+      {
+        "name": "사과",
+        "category": "Fruity"
+      },
+      {
+        "name": "살구",
+        "category": "Fruity"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "파나마",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81ec-a7e8-fc3e1001a29e-m1",
+      "name": "코르타도",
+      "price": 4800,
+      "imageUrl": "",
+      "description": "에스프레소와 따뜻한 우유를 1:1 비율로 섞은 커피 음료입니다. 커피의 진한 풍미를 그대로 느낄 수 있습니다."
+    },
+    {
+      "id": "3456e613-742a-81ec-a7e8-fc3e1001a29e-m2",
+      "name": "라벤더라떼",
+      "price": 5500,
+      "imageUrl": "",
+      "description": "카페라테에 라벤더 시럽이 들어간 음료입니다."
+    }
+  ],
+  "tags": [
+    {
+      "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+      "name": "대중적인",
+      "imageUrl": ""
+    },
+    {
+      "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+      "name": "라떼 맛집",
+      "imageUrl": ""
+    },
+    {
+      "id": "0bf60d10-7f76-424f-97f3-4450ad284d73",
+      "name": "과일",
+      "imageUrl": ""
+    },
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": null
+}

--- a/public/data/details/3456e613-742a-81ee-ace8-c0d60cf1860f.json
+++ b/public/data/details/3456e613-742a-81ee-ace8-c0d60cf1860f.json
@@ -1,0 +1,94 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81ee-ace8-c0d60cf1860f",
+    "reasonForSelection": "로스터리 카페. 기본 커피는 자체 블렌딩인 세르파와 그랑블루 중에서 선택하며 디카페인도 가능하다. 다양한 싱글오리진 원두를 갖추고 있어 핸드 드립을 즐기기 좋으며, 라테는 시그니처 커피인 파라마운트화이트를 추천한다.",
+    "naverMapUrl": "https://naver.me/5vcHYFEH",
+    "name": "써밋컬쳐 신촌",
+    "nearestStation": "신촌",
+    "location": "서울 마포구 신촌로14안길 11 엘루체 102호 SUMMIT 신촌점",
+    "price": 4800,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGHEyQbmHIUAMC4AR3ow2j5G4V-Rn1B9JDLTP0j1kttYjIeCIra1CT9E66adjwaHSxbSEu9wCzHe9aXx8Mfe7YWtq84Qant990=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "써밋컬쳐 신촌점",
+        "uri": "https://maps.google.com/maps/contrib/117990096595257196919"
+      },
+      {
+        "displayName": "박원재",
+        "uri": "https://maps.google.com/maps/contrib/104628043233507030228"
+      },
+      {
+        "displayName": "IAKOV PAK",
+        "uri": "https://maps.google.com/maps/contrib/103868824186246336228"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81ee-ace8-c0d60cf1860f-bean",
+    "description": "중강배전의 합리적인 가격 낮은 톤의 산미, 묵직한 단맛, 캐러멜과 쌉싸름한 다크초콜릿의 후미를 가집니다. 데일리 커피에 초점을 맞춘 커피입니다.",
+    "name": "셰르파",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "묵직한 바디",
+        "category": "Other"
+      },
+      {
+        "name": "고소한",
+        "category": "Other"
+      },
+      {
+        "name": "다크 초콜릿",
+        "category": "Nutty/Cocoa"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "네팔",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "MEDIUM"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81ee-ace8-c0d60cf1860f-m1",
+      "name": "아메리카노",
+      "price": 4800,
+      "imageUrl": "",
+      "description": "깔끔하면서도 깊은 맛 데일리 커피로 가장 많은 사랑을 받는 커피"
+    },
+    {
+      "id": "3456e613-742a-81ee-ace8-c0d60cf1860f-m2",
+      "name": "오늘의 커피",
+      "price": 6000,
+      "imageUrl": "",
+      "description": "맛있는 핸드드립 커피를 합리적인 가격으로 만나보실 수 있습니다"
+    }
+  ],
+  "tags": [
+    {
+      "id": "d944c5dd-803f-4f2c-96c5-8a6390fd1b95",
+      "name": "블루리본",
+      "imageUrl": ""
+    },
+    {
+      "id": "f7672ade-797b-4369-8bd5-98a9931a29c9",
+      "name": "시그니처",
+      "imageUrl": ""
+    },
+    {
+      "id": "683fad1f-1a5d-40c4-9ff8-77177b5d009f",
+      "name": "대중적인",
+      "imageUrl": ""
+    },
+    {
+      "id": "45507d6d-9817-4f8c-a23b-2f119d9101d2",
+      "name": "드립커피",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": "2025-03-29"
+}

--- a/public/data/details/3456e613-742a-81f9-9628-e740514d4c20.json
+++ b/public/data/details/3456e613-742a-81f9-9628-e740514d4c20.json
@@ -1,0 +1,92 @@
+{
+  "cafe": {
+    "id": "3456e613-742a-81f9-9628-e740514d4c20",
+    "reasonForSelection": "딥블루레이크는 코리아 커피 로스팅 대회에서 예선 1위, 결선 6위의 수살 뿐만 아니라 카페쇼나 월픽행사 등 꾸준한 활동을 통해 어쩌구저쩌구 하고 있습니다.",
+    "naverMapUrl": "https://naver.me/xk1nSZvN",
+    "name": "딥블루레이크",
+    "nearestStation": "망원",
+    "location": "서울 마포구 포은로6길 11",
+    "price": 6000,
+    "mainImageUrl": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOXoom62MK8N_m7T8xw9r_r6m30elu4Otmky-kBHx1faN1wLqoPnSJxK5ggQfATRy_4X0EcGj6DbFIHE725djstgqOsD8kBNoy_8D32CCPd6Quiaam5Hrdh6Y9ifZbXuaaJbj9VDKERBM3xq14=s4800-w800"
+    ],
+    "imageAttributions": [
+      {
+        "displayName": "히둥 heedoong",
+        "uri": "https://maps.google.com/maps/contrib/110139067500832058171"
+      },
+      {
+        "displayName": "Novia",
+        "uri": "https://maps.google.com/maps/contrib/111708720672506861891"
+      },
+      {
+        "displayName": "Jay",
+        "uri": "https://maps.google.com/maps/contrib/108669663780773449177"
+      },
+      {
+        "displayName": "B K",
+        "uri": "https://maps.google.com/maps/contrib/102736215150568380319"
+      },
+      {
+        "displayName": "Paul Leong",
+        "uri": "https://maps.google.com/maps/contrib/107174367799723961278"
+      }
+    ]
+  },
+  "coffeeBean": {
+    "id": "3456e613-742a-81f9-9628-e740514d4c20-bean",
+    "description": "농장주 2011년 엄하용의 파젠다 엄. 현재는 아들인 엄보람이 월드바리스타 챔피언. 비스킷이나 볶은 땅콩을 연상시키는 기존 브라질 커피와 달리 시트러스 계열의 맛을 강조하는.",
+    "name": "브라질 파젠다 엄 파라이소 카투아이81",
+    "engName": "",
+    "flavors": [
+      {
+        "name": "감귤",
+        "category": "Fruity"
+      },
+      {
+        "name": "베리",
+        "category": "Fruity"
+      },
+      {
+        "name": "해바라기씨",
+        "category": "Other"
+      }
+    ],
+    "countryOfOrigin": [
+      {
+        "name": "파젠다 엄",
+        "flagImageUrl": ""
+      }
+    ],
+    "roastingPoint": "LIGHT"
+  },
+  "menus": [
+    {
+      "id": "3456e613-742a-81f9-9628-e740514d4c20-m1",
+      "name": "커피러버",
+      "price": 6000,
+      "imageUrl": "",
+      "description": "싱글 에스프레소를 드신 후 탄산수 입가심 후 싱글샷이 들어간 플랫화이트"
+    },
+    {
+      "id": "3456e613-742a-81f9-9628-e740514d4c20-m2",
+      "name": "플랫화이트",
+      "price": 5500,
+      "imageUrl": "",
+      "description": "싱글오리진 커피에 상하목장 우유 제공"
+    }
+  ],
+  "tags": [
+    {
+      "id": "c8b9f0dd-8d54-481e-8e3a-edbf7929cbb9",
+      "name": "싱글오리진",
+      "imageUrl": ""
+    },
+    {
+      "id": "71a7dbcb-7bbf-4f99-bbdb-82e294e688ae",
+      "name": "라떼 맛집",
+      "imageUrl": ""
+    }
+  ],
+  "updatedAt": null
+}

--- a/public/data/image-enrichment.json
+++ b/public/data/image-enrichment.json
@@ -1,0 +1,1238 @@
+{
+  "3456e613-742a-8105-a51b-f7ef853d6b45": {
+    "placeId": "ChIJz_vKBdiZfDURHcFqcgZHEs0",
+    "placeName": "TREMOR Coffee Works",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNVzF3tI0t0FkJBkRM5mz4fi2xUIu6Cgv1hZcnp65lZtdcBsfy-l2GR7hQU6rVoJaP2h7cOM8H-xgVtDtYvvI6_zfPGF1Swt_KxRjN9WXLqhHpLG92ACM1fZwrkMxSzgXjOeFfeAZ-J2rHuyQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZM-ZTPDpDcJSnH2EcIqHmo4VRtXynqWw3xcpod_Fu13GhtfmSWWWkcSxMfU4_qICYh51X8Ge3ZLNCAfZIF6z3kV_gRxutL4Cv1PSmXVJxt3n4uWFJjSWRZ8eUSui-rSIKEI79xVBRoHuV_NO--l41NP=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOee56EiVHfBWoTPaMBM8P3_M5UZWXVHP-xZ8_FToIXpG_lMYr3qQR6yj8M8zi5Z5YyasevJ_8LuXsT2qCZN5VL2eed9F3-L3MUsBf0gHEcIj7bDh7U0IhD6IVeCUlPECZptE2mpT243qqn=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPf9X5z6Oj502bkc5-P0FLCjlcKeEZG8T3r1fWXOgTH8psfE38DA5Z_Pk5FVSbym2ty41QpnN9_UauMGwVIpCRkDpP4hnIFjaYI9meS6YcOAR78SK8BRsrBJHd92tGnZ9GCsr7d_BBV-eS1VW7cCRIyrQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNV_v2hUPhslxaNLy2AoeL_KoXda9zvM60dfhWBBR-IlX5QbJWI5Ssk0lceXBcLd-4o5saMYpznrdyrcPRGhitu8Fnt4HEizJvasGtYTz2h8Chktd9zwq8Feniy6soHhSUZNmh7N2v0RgfRiQ=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "John Swift",
+        "uri": "https://maps.google.com/maps/contrib/103902733045144332915"
+      },
+      {
+        "displayName": "Anna Zhilina",
+        "uri": "https://maps.google.com/maps/contrib/100943356577614589388"
+      },
+      {
+        "displayName": "Agnieszka Witczak",
+        "uri": "https://maps.google.com/maps/contrib/115311569956998214591"
+      },
+      {
+        "displayName": "Ricehon",
+        "uri": "https://maps.google.com/maps/contrib/101812471017667912990"
+      }
+    ]
+  },
+  "3456e613-742a-8106-ba14-cf8ebd0f069c": {
+    "placeId": "ChIJYbcWui6ZfDUR049-VbPLa2s",
+    "placeName": "피피커피 PP coffee",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPq6s-zDH5TvI-D_3-Q_-qm_JxmYhOv7mCLVMk4tco4M_H4q1Gsy5P2lk8DhlF_SNuhApKZE5BKMeBtb38juIDDxeonpwPxGZ7vf_JvawXqD_24Um3lVlLUgE87kr7_yUE5p4Me7Q-2kup2BA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZP6Hrxf8Z94w6QnAiyrzqUZzEku7OZS89qVyY995dTRUuEJLFq5CLNQ_mEdf0OyIQPR1_i2ZxbxDrxPC-p2gxcZK17-1cikjSr40BB1s-1Yh8HiGC8hq5-vZf7HKai_bFCN8f9dDkj7MyNFEIpFNqYNDw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOypghhoMRAY9I7dg4pfmWC7yn1iNvofv7_A_XgpNxeTlm3xNEIsnS7b7JE_A8dQBHRG6DhhCxC0wQSXe5wvLd679zJxDqEKnJ99PTVnu3N4BPgO251QuzhFSbDMnDvuh4f4w9jv8wnxOwhYPni5ACl=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNlSpWaR3mdrIdsGXYQZXeb9ID7LmoxoVYUsrfKQ-S9bVrAxybEuVm6g8iAop-h9mJZ62MHuI1i1xDcW3HZpGJGKMocnbkr7aO23WZ-K5qvFX5BMW-VpCBQqkDIaGgRzZ3EDeawR1RuxokBL7aYfUQY=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNrbyWWWHm89uNcUY8UXvHZ_Mmg_ee8htqdspRHOir_BP9Q0kwpfGgrNlTryGDRFYH8N_5Zbw3Aaf3ZryU5sLupc5dLgfel3b4aNh9FKnn9WWwtqmvUYDfb1dxeaa96zlDeqweCLWJ0RHGl3QokMevv=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "SK. Lee",
+        "uri": "https://maps.google.com/maps/contrib/100330785291388672862"
+      },
+      {
+        "displayName": "EUNJEONG CHO",
+        "uri": "https://maps.google.com/maps/contrib/102848365565532411199"
+      },
+      {
+        "displayName": "Virak Horn",
+        "uri": "https://maps.google.com/maps/contrib/110877812762636938895"
+      },
+      {
+        "displayName": "이연숙",
+        "uri": "https://maps.google.com/maps/contrib/113102366656449143137"
+      }
+    ]
+  },
+  "3456e613-742a-810c-9314-c6c3dca0c7d0": {
+    "placeId": "ChIJibSqr6aZfDUR9dX4_-D021o",
+    "placeName": "커넥츠커피 망원점",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMoDd1eUjM-E7MDr0eLoMPgHxMs83lDUq_dxusWDfbRcOvm2EPMu6poLZ7rC4OvmVhQTuuv7-2XQf9RVssrH5qdr6UbzRNbgJSvUmmto_CcDs81-80qb9uXZDtyqm7Kwh2qD9eEpmPis8fAqA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZObn4lRHpq4As4CytkkUjsZfZLfi1mtJxdNoSX072WlQn71DO9YT1bj53LXEfZVzAoIbrFQaPLbUB-00wVboE9ILpT5rEM2KSuRwgfueZxQsCnmbSzJYi1eRfRYOMbFyy9rtuGhqOt2ZXZe=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNxsjo6A0LBGFAVZadDajBFi7_UCu5bVBXXn5deadsbBBIfQU62lhj-YFDw0t7UjDZJOYBu7w2ySebGTW1JvjOfM6L7bZ0wkJQ5nE_0FXbW56241Qjjis_ekTVcFrUH8-uM8vM5ppYTy8U1euo=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNUt7BQYBX3QM8LOs6ZWbI4UPN2fJrBXXRxlMQvDqStB-lwwzzV1usCvL1AmSVjIwmUuEat68SBIzUw3c6cPeqYWgt-_3aRE358OaNLGjwwU-UDJK0tUaPlPZq_xwsrQuWd-pEE4xGuiSpMkg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNT1I6aAyWSohOYTYCGFw6O81O-35XOlEij1GIlcqAlKM7X4OkD0npBGD0Gt2fe_oiEMM3T5ZMwk8lRYzuocl0MRhjt_mUVa2GKbyR4KKgo2MW79Hxm7fTv2kD39X5Xuirm4N2ol2XC1DrgA7tKAo_Gbw=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "홍",
+        "uri": "https://maps.google.com/maps/contrib/109540277806552877850"
+      },
+      {
+        "displayName": "뚜뚜루뚜뚜",
+        "uri": "https://maps.google.com/maps/contrib/116053173347867842673"
+      },
+      {
+        "displayName": "ree T",
+        "uri": "https://maps.google.com/maps/contrib/113968091913809736158"
+      },
+      {
+        "displayName": "JINU YOUN",
+        "uri": "https://maps.google.com/maps/contrib/112925352849439490899"
+      },
+      {
+        "displayName": "ruin Sung Mean Pae",
+        "uri": "https://maps.google.com/maps/contrib/102778409927121337507"
+      }
+    ]
+  },
+  "3456e613-742a-810c-acae-d08ae2fbcf73": {
+    "placeId": "ChIJ7TzODACZfDUR9JrtUd4bAU0",
+    "placeName": "커피 리브레 파란점",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqE5eHmZGdw7P5_mCUk3g9v8IZy0-e2QYQIOAZ8ovRwjQdCXGol3vPPVem5rwMYQiuWpxk-KWFS0WbGbbswxQX-D1w_FuxjD-Xo=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqESvQ_kpn-BJX1GbZScrqcCRU-zwb96e4yjcwnWBKtnK4CKYIHUYwPahxl2cxFX-Xy_4Z1tt4A-OAjykSO3xfXkPfU22B7PSNQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZP6_eBwyk1tCZ4BbyI-Cqv0TByn7ZwhewfTKNj6KOp7NeRP5ezgJr9ZobHsIPtN9iGMg0hdHHLOOd3hlynxO5uAZhRhJUgYFLCifLVJ5RdzDnS_2qL2dKkbiCw6dtCnO4Pb2CbuVjALcvayDyXnql4hxg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMh5S50lJWPxekDmD1HfHeafj3Y2J2fBxjodCT_FAr_7M0iNkUhxymm9h_Q-mpJadUSI-DPcEgMpmqP3O3wPBEllbFWy-lK-23tAi4azzDwQN04wZn7VnrXRjik4NSkwYEP0dr0KZFl_TWEeyIZ_S9-bQ=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqHLUJ2J6S5laAnPtjMuzLwzWrbqV5n_glNXgvbh1BfBWvwwJQnP736_9pxspTCTNrYu-sBOF_p6I6S_CYPPKTaBbhqBO9aZB0w=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "커피 리브레 파란점",
+        "uri": "https://maps.google.com/maps/contrib/106611001321070135527"
+      },
+      {
+        "displayName": "4885",
+        "uri": "https://maps.google.com/maps/contrib/101174457893511364385"
+      }
+    ]
+  },
+  "3456e613-742a-8112-9bcd-d1a2b77758c2": {
+    "placeId": "ChIJTV-3mI-jfDURc70bI9a5s8k",
+    "placeName": "로투스 로스팅랩 Lotus Roasting Lab",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGO2yHGFbyVTNwGcYDBQXGD3nc5mhePDP7NwsuP68pFPTVdDogDjcqBr05K9TBLhtXVJx32jNJ4p7At4EdzbjIvGSNWlJCwI0U=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqFTTlA2tqEU-6FHxjGjzY66uAblTHJu7ghLvQzP22AY2NYSb6En563DXp-vgD3jnIX2IiFxTH-jYMA0Ntedtp-Kx8TUkLOBAF0=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqFCvltVlcWruFYPsAcuMUgxnXwAEXlP2UAL0r7VtBlTvcPux9m9m7mE72JUSYr4TYIdViQAV4SS6BWCKmHZXgYuZ621rIBcQ0s=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNTvDny5d8NON5mUDMEeCNkgQf3v0CYFk5NRz1W3ZbnQvLv0T5qFmlWzjnL0S6OIwBSiqJtcA4K_i83feFcvaWNNJXNDGVYzi90RpuYxH4Zh0ZwneAFDURtIt_PXq8B5hpKQE5jB3cXV22oof1LBDWGvQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMiwYBd4QMc0hvUxlDNTDv45ymjtCAWFq5QJdilHQ9eN3wKY97Tn_vmomVmTAWZt0O4CDBcf3jlXLKAVki06lOYoDrVCUfnKXviWktltgmQzZLLdPCvHy2rbohDMbCIN-UycsYQIxej7ECNIg=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "로투스 로스팅랩 Lotus Roasting Lab",
+        "uri": "https://maps.google.com/maps/contrib/103285944292778799128"
+      },
+      {
+        "displayName": "Jinhwan Kim",
+        "uri": "https://maps.google.com/maps/contrib/117556547785697924449"
+      },
+      {
+        "displayName": "Stephanie Young-Eun Jung",
+        "uri": "https://maps.google.com/maps/contrib/102648209263753189589"
+      }
+    ]
+  },
+  "3456e613-742a-8117-998a-e76b75241b88": {
+    "placeId": "ChIJedlDzuWifDURBaOCaa5hkL4",
+    "placeName": "커피한약방",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNp3w0uyaLAXXoned2nURVQL8iMBiH08O61of7a6sdd6n2vxJjYjH9sJFJtCs2joCfiZbYOeb-k35Rx6nfzCsbpYzvYUeW8v9bWM09q-P8A4NPVdvSmjIQtDbb9jwe1uChdSrbbpCzcb1eF=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPBycmPrMq9l4-8YglHNtXctR3i2PGFCLaZOflzTvyft3h8uLR46bXROaDrfewIaYspiK_xYSigslQK5aebWF3pnwaKwAyFi7eUoMxlFVea7wqdHPJ9tF7PglpQl2f1Eygsb5rtbVEDnnalbA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOgoea073J9ZD6Vu3PBfR6Mf4A_RbDfPi9V6W9uHKA8Irumdm6w-gB2fpZPOlRhu-5Gl268xmNhl2YXypo_AMjgJyLWdRvPCy-SgAgro_aw4Jl7f_SM9wSpbu20x2raAzg94qJoB_Wgq2EXVgpYAdcI=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOSBlb1pkKJsu0AsM__wK9A_rhFYDbx11gjRF_rXZ_gK15vB9DVO6NA-hTyzr16MoU38WgM3sxeioyOn5q0WRRyvpngDqxb6boEnFrSbiYFcyPJdDDrw_ffxZ_s_2cfnfJWlFTqihY2qHvvGQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMXnQH5Pthb-ZpwqjxuBH2hMNZa8bZLHAdHrXTmeDL5WaiaeKY5Xp1KSoJJmj1Gt-l5yMzm5SK3qAbRtUJNYyBhVBpJTIqDV9BPFaL-NrTro9aHkJ5rjPltPGJ3r_2UXjG8zBQwC6xevXaSQJKH7H2k4w=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "一起玩生活",
+        "uri": "https://maps.google.com/maps/contrib/118205409563621553270"
+      },
+      {
+        "displayName": "Kyung-Jun Lee",
+        "uri": "https://maps.google.com/maps/contrib/111248486244811888553"
+      },
+      {
+        "displayName": "Jo “gorby” L",
+        "uri": "https://maps.google.com/maps/contrib/109986623119636476956"
+      },
+      {
+        "displayName": "Bartek",
+        "uri": "https://maps.google.com/maps/contrib/109741509203395903561"
+      },
+      {
+        "displayName": "김정호",
+        "uri": "https://maps.google.com/maps/contrib/115353743468053479499"
+      }
+    ]
+  },
+  "3456e613-742a-811c-b069-cda489e0a9dc": {
+    "placeId": "ChIJm7hDt92ifDUR0YI7AaQYLvo",
+    "placeName": "아마츄어작업실",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN9AX14pFZwXCu7y_revxvj42dbrGXbAU1_o1ELnYF2J85R_YeIgiHjWNW8CXdnSwc80ajJikaImOL_Bq_H5-QcN0tMVVb0BUhu1D91SkP8o6vSYopvffM3Wi3Y0rNf7ySeMokdkfAOykfz=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOM74eocZgztWX2MrcFlTiy8k8Nyz8ObTbvVk_iYQauVEyMwqkh2uySa-jEg_PqFcqs3shW8OHJW06djkBir5TMos-9do5j9pVQsWP1-d2CfZaDIdrjMC7zAruNna8A5JDcpCRgZalvc8z0R6o=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPvuZ8PgqOY2Zu_qe3ZvvcUkj7lCewu740Rpj-35BnrAsYzV4hYvwFKjekDPRV-KfuTh2p37cvTLCF0e4LvKkjV4lh9uuwG2-Jn5fQyAqX9Ho2_BAqcr5J4bkamcl0EuT4uENcO9SlHhPyYZqs=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOfyaoz2jjOEsf3_pN7O5VefP9HINEwgsj8D-JF3s0qNnvzBZdTwsXMozdn46_1iHLJKZDt1Krp6_0ObS4c0eCZYuDN-ZghD0MD1YyWOzthkKe2DRvoqYWIfPatmvVor3uPQ_lfjODzRaPV0Q=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMZRWdJMD3D34MjsB6mF6Lc2mWj-9fi1_n2xzWc0BExfLqOyVKcpedeM4ekDYujGjcXAJWdTKc4KAJODYrXaUaLEmgwH59VTfnywIxyWzsJ8NIzoKL2IGbFgjlIoxcS2yNvZuSeuXP1p2OaeAJYi9sx=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "이주원",
+        "uri": "https://maps.google.com/maps/contrib/113108122614507003609"
+      },
+      {
+        "displayName": "예지앞사",
+        "uri": "https://maps.google.com/maps/contrib/107087717340452475497"
+      },
+      {
+        "displayName": "환환",
+        "uri": "https://maps.google.com/maps/contrib/107790157174004513891"
+      },
+      {
+        "displayName": "EUNJEONG CHO",
+        "uri": "https://maps.google.com/maps/contrib/102848365565532411199"
+      }
+    ]
+  },
+  "3456e613-742a-8121-a957-fc1f5cb28894": {
+    "placeId": "ChIJRTb_hKOjfDURQhHwwxDLWOY",
+    "placeName": "펠트커피 청계천점",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO4N7B2-f52cmt-tYwM42IITAf5LFPG74_8I3Py3HgY9_39QMy-pu9Y8SOGVm47H3q3QvvNnBGYPotci5C3JD534Du-ZCdR80LaAcfGUAY3cutmdWMBwPO_1v1ZZl-fmGeg6AywsTZVJVIG8ys=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPld91bqioQbLsOo3whcGSKES6XLB7WbIgHRH9akpfGCW-SjJNxR1IQG-Uq3falOoMWZe2YCpcR_J3s_oIp_Her97ag4SB4J2dQr7T-fWNeLN5Y4bjZLHFBXOBA2g8w-IVJEY_l8R-Myv873SU=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZORN5DxIgHRx6ZoNamgx_1RLS6vOZRntnSYV0_y5qVbAK53NqzanCDqMXWC1iVGqMCTkVpYj4IPpGBSN3bku7kEqjbSFQixhGKjAwADPdmOLOIspEdTgXMWEpJfzJpaW9Z1lud-DQtwsVNfKvvHZakf1g=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOaQzh1CZMMVikSZspNZCnjJKBgeDk3rtbrwThOHhfHeuz0_HXpGOyYR3zTHQv7IW_Y_n7reeYiWKsJzwEhL7Zl4rIpoZIxn0_3PBpxoOGhMKSWpzYVnJL3-QJbT6mtFHNDwBHlLMWdttGhkg8KFT3XgA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOadGCgWJo1whrR3Uo0Eagq_mCF2RNe3YHRkL3NvDG9AnRHyyg4jm2uQTMfPW9vUJHoCYqFr8HErYPRPzENgOKn0CSf--B4zKnyhuBkcIB9pCU5T_tHwMHWOhuIF1IP6ji2gdga5WZke0ECjObu_kNwhg=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "송명후",
+        "uri": "https://maps.google.com/maps/contrib/112462352094917846513"
+      },
+      {
+        "displayName": "A",
+        "uri": "https://maps.google.com/maps/contrib/114273467874530356771"
+      },
+      {
+        "displayName": "Dariusz G",
+        "uri": "https://maps.google.com/maps/contrib/100972152106159291910"
+      },
+      {
+        "displayName": "KS Choi (Gravity15)",
+        "uri": "https://maps.google.com/maps/contrib/111676510720878147594"
+      },
+      {
+        "displayName": "Greysuitcase",
+        "uri": "https://maps.google.com/maps/contrib/115915227251650202552"
+      }
+    ]
+  },
+  "3456e613-742a-812e-b998-ecb84f92fe35": {
+    "placeId": "ChIJzyMmnNGZfDURwMwy6FCN8gk",
+    "placeName": "평형",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqEF3B7WteHj1IhJfhJ3g-DM8r4pTmdhoXDdjpjVvb8GNg_7ZxtEN-g3yn7OxFbSknMiSRUijdesImFveGx9uYGjCmLXyx33bRo=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPrfaU3_gLTGnFzziWXmgrDcIu8BlmzEztwVv9coL8TsQ6hQ2sMIAGB_NcQweCWSsyTnN5AMliydmwoh36Tj53shNjMbgSSm2DFZkO7u48GbROcsKYKHHZIZmP5Dj7CCbvQSTOCRHTXzpUFzw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOqrd25Roys3a-iZRn_BV9yMIWd2UzrjRSG8_FYJGL8F-p5K6jAR-v1QFQfDHHkJExH2D87LNpLGk5Gg8gL7-Za3JbKBy17DSIG-bG4I3tl3c_ACg6-yLeEGJYDfPWxvDiVJH96bzj6mU9Q=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOCIZ7ILQ-_YplqzTL0_3885ryBAZnSCeAGIP11w7qWeLKW8Lx-aras1CgSeAMSZpZ6xEr8uwsxNtRFlhbotcgEmdhB91uuofa96VBv7BfbmsDYhI4S8UieHr0_I_ZvzfoW0DgVijjST_96Cw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMMfgLsH-_ZeYAJLQaBku2pEarcyLjOUHV5pwpXDdZLjwn2mJKKXBAZSYZ2rLMRRmqhKFU70ubQdHtsttJSCDCJFF_UL4aGZAEIRFWFcgG3uH3To5hycpaoW-VSgGFhenKcY2WpHPsUs6JQUpY=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "평형",
+        "uri": "https://maps.google.com/maps/contrib/103391835054553483549"
+      },
+      {
+        "displayName": "A",
+        "uri": "https://maps.google.com/maps/contrib/114273467874530356771"
+      },
+      {
+        "displayName": "Sesame Sprinkles",
+        "uri": "https://maps.google.com/maps/contrib/114630405221931250347"
+      },
+      {
+        "displayName": "이동윤 (폭스마피아)",
+        "uri": "https://maps.google.com/maps/contrib/110412043580559528745"
+      }
+    ]
+  },
+  "3456e613-742a-812f-8185-f5e79c36f5e6": {
+    "placeId": "ChIJGXtXqXSjfDURdEkT62Gs26I",
+    "placeName": "커피스니퍼 서울 시청점 (Koffee Sniffer Seoul City Hall)",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqG4Q9pfPVDTyNmQKTb0mLFHLDFSUGFLQUfshfnCA-hOyMJU5a3FNXoCURoydMXYqxfA5CjUHjDfp6R_gxew8xkGCdeWs5j_Yss=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqG2jmzJkoeQLCjoJZwPKL2n-OX8EQBUAZ9l7QVu7IM7iVSE2YygoUT-MKG66jMEdDHeVu-xKuPvguwfoWfOOHREVBNJToDtXeA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNLTq9d0zc6qY6jqfC65BhbQ0CdTz0h5oljFe60Ap4sZGhT7tSD7uMEBdiYIjYFLiPxJHVZQz2pJyrGhop-3JzyaY-hH06OrLXcSNebA2Ml03t6_f52fbt8OrQskux2STY9sIwQcr1G1cpHdG8=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMRo0LRyVmXK7N8DT0Smz2zuxEnIfnm0tBeD4S_TvAiCo1GQO7YzB2zSomttL8zsrbiryUFcfhUon1zagEeO_V0tOyb2FW0YX9INgMMRbvQoqUEeEwurn8WYIeL28VDPsNJnqnK7_jdjsypIQ4=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPy8joCjwbEZB4KHG6rr5KA2MGvbwfo4XEfO4y47ZtZgFcfbwEiHKPmoCL79AjoTG6hm7Py7WBdZoDKhzqwLI72m5ZvJlxCQWwjD5giHjtLpsVi2uFkAzRIByXYjVTYYdeej1bFIaozbyThLES8vjFvxQ=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "커피스니퍼 서울 시청점 (Koffee Sniffer Seoul City Hall)",
+        "uri": "https://maps.google.com/maps/contrib/105084200904133051989"
+      },
+      {
+        "displayName": "Josemaria Rafael Montemayor",
+        "uri": "https://maps.google.com/maps/contrib/105628346135126353482"
+      },
+      {
+        "displayName": "KunTa Tsai",
+        "uri": "https://maps.google.com/maps/contrib/114875921730523192845"
+      },
+      {
+        "displayName": "Анастасия Босько",
+        "uri": "https://maps.google.com/maps/contrib/109559085324617342384"
+      }
+    ]
+  },
+  "3456e613-742a-8138-9e91-ed9e1a3863fc": {
+    "placeId": "ChIJz1L6DX2jfDURmM9z-VABLQo",
+    "placeName": "ACR • Alegria Coffee Roasters",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqEh9OZOx1OceUcsEuQIUuFZc1Ow4oBmgBv0QlV0rLL8V0O-MPVeDYjGKEKHk5cOJnxs4htFl7QdLYPN2IL4slRyOgyOjwWVrEU=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqEL8mbV7G3TsNL8-QCf4MgE1FTURteONLkxCNr8s-W0JdmhsmvmaWV2m6XnKwrdZYRbJr9WCd_ExruHThYX6VQMUvq0jDWgyME=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMOuLvTtB8vSDW4S-uFOXyU8NnW4kAM7ctqdY8mxxIZI5C86PmV-t2F1eFpjLUCwMI6qTg8IcMYQ-3cDAegW36rN_xctZ4nInxRY-GQqhIQ8KAgsIlf8cBt9naAfWra8cRVNVuLjC895FxFJg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMkiQxvhgddG-mkLA3HjqXE3eh9jnwSQFhNZLW2hHOeAo-S9-tcg6tgJHn0_BDHSvuTyCAXUW0PsfJgSk-NhXNIrNrD3F7xTK3rqC-BvHGnE8cx5ITpEaXCeWWEC6ln8j9wC0Ce6fKn174Q3LFl_ihV=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOkZLxXXoTGIioPw_0d7MyyuS-69jVJwSFDIRRZHcN_is-1bR4BdOxiKS7-IBl2mrfT--uDQkokslRftNrzhtg2AO1fpTm6pbV818bi3jSW3Z7dd1ff2xfpG3atCOLtI_1jSfA2a0I_valORVJFyjW0wA=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "ACR • Alegria Coffee Roasters",
+        "uri": "https://maps.google.com/maps/contrib/113795254722403618287"
+      },
+      {
+        "displayName": "Supakij Khomvilai",
+        "uri": "https://maps.google.com/maps/contrib/109043515752937696097"
+      },
+      {
+        "displayName": "Lisa Nguyen-Maher",
+        "uri": "https://maps.google.com/maps/contrib/102654207693925420526"
+      },
+      {
+        "displayName": "ILSEOP LIM",
+        "uri": "https://maps.google.com/maps/contrib/106619759096815157789"
+      }
+    ]
+  },
+  "3456e613-742a-8147-8641-e38b38b62205": {
+    "placeId": "ChIJq2PHEtuifDURmv_bIIwdEJo",
+    "placeName": "프릳츠 원서",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO-nV_gmikHRJ-xoMI5fF6XtLob07McKWAN-6L598XgyUC1bW-GSCz4UnygkRdpqM3R7pbNuPSjNeaZ4n9nPkCL-tY89Tj2jupdwZoQJTggieGvgI9v42V226ofXxkesg6UiGO2PIzVdd331O0=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOkbMTT7lA0Rmfq0Aw3L3nMR3FGepBKdnW6XLpSnmvMXZoi82fdhddONAeDJBfPvGiIjVcmVOC7S5NxskgVkifd37MNcdaITtAKbLsMcfZfp_dpkGjlU2A1vuAhG_N2CuFSAgpj58jlSO0fuwM_i4h--A=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNO0oHY4YsI9wA-6S6xg-R5qTxNlljTB_bumS8ql7y6N43q8D5im7iEnUMo4h_DsbVzuUV3nB-veWTgRYvYHGG-A5eTS0-eTirOiHbjpraOcTwb1BX_Yafw5YKGPMPKhIJ8Ny9vymVDVgMi=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMq9tlqmekOBdHPY3EBe8S31f-qYw1DYXQpmbn6o13R3SLcH5XnILnrO9wa6c8_kF_0maJ3yIuPVOkLYSXyBGM9uUxwnek1FyGjM83R0DziZkulbApwQrdBozuCA8xIUITyT9xbr2MPCT_Waz9_uwCu=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO1lkJbDtgDncb2Emjc4hwJ7_jXLD-VQaer0uwj5oCBk4Nh-1dpPPXoDxFS7sS_dBJgr5eIgCB3ZsRgOba3Bqhhrthn1hcdcaWqANDhH-S1q8W2aDn-939gQVV07-RxjiHfgoKLsB4vrfIxzM6IHL391Q=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "미소녀천재",
+        "uri": "https://maps.google.com/maps/contrib/102455295934134715215"
+      },
+      {
+        "displayName": "Vincent Quan",
+        "uri": "https://maps.google.com/maps/contrib/117963621997472463620"
+      },
+      {
+        "displayName": "Quintin Willekens",
+        "uri": "https://maps.google.com/maps/contrib/111317889570837386504"
+      },
+      {
+        "displayName": "Emanuele Grossi",
+        "uri": "https://maps.google.com/maps/contrib/100788145102071283393"
+      },
+      {
+        "displayName": "DAVID BAEK",
+        "uri": "https://maps.google.com/maps/contrib/110810419932627320272"
+      }
+    ]
+  },
+  "3456e613-742a-814b-9c2b-e3e9a61d55db": {
+    "placeId": "ChIJWxzLLdeZfDURdomTdcCXhMc",
+    "placeName": "블루보틀 홍대 카페",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNvK4UkiWYztGWTEesgXSS1m6xM701GReDczssoBSsX4OuBrpvB5ZauF0OFxJ9aIoqWHEBO0zTyVfZ7rr6azqfElHOyCCC1PChRB_mVy343i2lm6wQsVvuTxmjqrA8LXkAnLDe-dJsmAYfr27kqj81VVA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZObMBjEeGy2NZ1MwpoYsSPlYk_a5n06ILKoZNXMELHm98Z7F0OqvGGahT4-t1PXB-jfH4JGFwGEJF56Ftbm7dz7haf5iiIDiiFb-B44kYRF6UywHiRw8NnLlb47Rr4foY793skMw5IkcducLHg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNUrrV7zJn_0SHc97WoHXFwGb4YNSYWYrFZJ8HuhkTPVzvK8EpRnKyYH9YlMmk60RWKLoZrw-0ry03LUdalxcr_6WeP0U7JY8x26C9KA9mmN5DuT0EsxIwrRy7plpO98qakbAJdSwwICLwJJsM4gw_oIQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPj0E8p3ve6vu6Ddu4yFdwpTXfVbKlJ3W2sBev5yEiM7MK5p1YEFt4YFIsnPcCUsLOhwDLXyeTgV_5Z6K-pYblQSbUD-KlHKLTWA3LDxeKOgJ3epaDOjjr-TZs1P09bS0RgQNTtN16VAtCaRjUCIZAIJw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOKmCcv6lT5ySkuErbc_wt-H84leJctUJErxMu_Xupz6gmidO2rK8qcWNnABTso6nVKu6CCJBpQinn_X6uE4Cys6lbn4KcjziYNKyMMiomYjshzbk3PZFxWIrwVxK6b9Pz_EPRioKnx-t2WAkTHtKZ2yg=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "chris kim",
+        "uri": "https://maps.google.com/maps/contrib/109918877500250771711"
+      },
+      {
+        "displayName": "Ed Uyeshima",
+        "uri": "https://maps.google.com/maps/contrib/117870220400430151038"
+      },
+      {
+        "displayName": "楊佳穎",
+        "uri": "https://maps.google.com/maps/contrib/100137338779577016130"
+      },
+      {
+        "displayName": "林小美",
+        "uri": "https://maps.google.com/maps/contrib/113048015410695794636"
+      },
+      {
+        "displayName": "水水",
+        "uri": "https://maps.google.com/maps/contrib/100338572678216552813"
+      }
+    ]
+  },
+  "3456e613-742a-8154-afb6-d508a5bb3d47": {
+    "placeId": "ChIJ712FUOWifDURMrEzYFDR8vo",
+    "placeName": "커피 리브레 명동성당점",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGWpUdkX0HYEVtbM45bFI1nv0xi0tx1RYm56C_04VKwmTYQByWjQCDHFqzrVKSkw5BEQaVGhH1TqMxVQ1Fk1q_z04ZDUIkB-x8=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqH4KKEUdAKWQSpkeZMCCw4X6-t2Poz6qzpaHlE2Zck7Zo5Ndg5jWYXCymaV0eouB_SvRfEAvefDyPF-Bdfvmo-nLVsqmzWxeh8=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqGjsnd6vZ0yJOxYX7hJmN9kbx00jbU69cdA9Dfjgh4PKd7tMbxg7AFIzqoaqT0MQrZQdZvoc3e3J20LlqNWSQfeAKtUT-zKQZ4=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqH1O_vE_KZURRI6vUWhSvLtSXbaI_Kqoy6XuxDj6xuHMAksxTRhjlX_uD_r9xM6zah2jhMC5jkqYMmm_3TgjjA7Hl9pC2JwZIU=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNsg4OrlDxETB1V2DuPGBQromo9bIJlX2cQAht-pMRTSzqKeacYBpYceHU0oRoJQDfVHD9Pt2LsF5b1HTVFCN53AD86VXIK3otbhiCmp8wFTlPxdScpAcZwNQ4RmKGQdTaeKGoKMVVVSwZM-cvK9C63fg=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "커피 리브레 명동성당점",
+        "uri": "https://maps.google.com/maps/contrib/114189357670439873721"
+      },
+      {
+        "displayName": "byung jung lee",
+        "uri": "https://maps.google.com/maps/contrib/111097757597410979602"
+      }
+    ]
+  },
+  "3456e613-742a-8158-b139-d5dee62905dd": {
+    "placeId": "ChIJn2JCg5yZfDUR7ACwVDLtWaA",
+    "placeName": "인덴트 커피룸",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMr_c7bS_U5cIe8Raiv-ovMROHncOhtuivN5GThAmtPjXazAUpYNFZbg2UaNUw898di99RWdgl3lgio3Z-x8POaBeWCGzrJX6QuG2_vO7bpQl_pzNVSJMe5yriLvwjsEaw7KnASxn14xCIml3s=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMYP7hfZ1gAgyylnzYltkMteSKikTSHGqUMii5q4ZeKpjFFciqLOWPA_-5xO_etX-lqAz47DWc9RjnNVJwvLMwcdovAI32kUhtou1IrFeaEhHhiRiAuv_hGelTnObD1TiQV_uXM3yZ63beLSQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNdtxlbB9ArlnPV1E0-M259mflpuNmIn6h6z-KPjrJKmU6kMilCdbx_DxHMZan1p6QXe7UiMrhH7O9muyVi9MqEZ4A_ONIitymsuTWgil7BBKrN9WA01zYuimyJkZcfluGxmG89BmoEtoLwDkw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOjQ0G0NM3AxSqxdEO0O2kQ9bYdZs8Ofw4rLR-wSqdKOblekj8xSQ5f5udaD6Btm5z3PYLHTqj1cqGQuTW0Od96ZqutsLPHZZj9HNu0bwbYleR1VI608oljy0bOoVKZUyDEjHJPf7yGc3Njew=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPzF7kVEi8nY7C8_4DU-dA5IyFUU8d5hOfDFwMkrHuL-Gprbb2GaG1yBMTDJxyAJ3j7ZGCT4Z1dKXyP_GQN2Smw-XgnAe23xmk0C6IAQ16WfTxpv4-fDUPduRqovFUMXog0crax2FiYQJKcDo4=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "Newjin",
+        "uri": "https://maps.google.com/maps/contrib/105446364100325684675"
+      },
+      {
+        "displayName": "JINU YOUN",
+        "uri": "https://maps.google.com/maps/contrib/112925352849439490899"
+      }
+    ]
+  },
+  "3456e613-742a-815b-90d7-ef91d85b98aa": {
+    "placeId": "ChIJcRoYS8KYfDURexH0nIaY6Mc",
+    "placeName": "말릭커피 Malic coffee",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqHDD_HYuYPINqkRY7bJ0L_JraoILEzG5-tx9CgrohUDcWy5HFZqSAhQrvJ1qS5WBGURCoqO2x1bK2n5h0NXCtK8lj3_xzHPY9s=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqETYkKykVlmXPKAJ4F2_fLTeFPU9VCflheNw9WwLw81-Z1G3SVPEo3IF5NntB_S6dnme6OntxARoqHRmzEMmrWBlyuGg1_-WrQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOzvpI9WIYyMY_eY1x34R_4W8dfAxmL3bgnT7EeRBO-9njfR7v1Bsnhri5LkiuFrXQjVJcMC-eIz3C1-CVIuvPil1ok9Hrv9TLoqJkYrZgzwN4UshFAFKCpDESPdVOReonF9fWUuI0m4BCr-cH_04cn=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMvjpuSVZdaJzqFTm-R_uiaw2MI0cdignzu35Nep0qkfbGIzP2b5yTtGWEB4NFv2Smwwcb7SUk-1T1-aMkV3ztUR3oaKYJ-ERdmdjq2zuMlE1-wLqEAKawmrdKH0ko7g_YDXKD5q6JYryW3ug=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNnE18zihOJZLY0DUIObndUoLKFTs7OWIgXJw0yxfvgUIF2urD6rKoqkg6yCAqvmcuRJOQ4nNLopGX_On7SqRoXs0I95d7yTpGqT3YG5iG2mlhd6v9iTnPiEzxzzG55wBTbYeDGqz6BfYrdhPm8SMxG=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "말릭커피 Malic coffee",
+        "uri": "https://maps.google.com/maps/contrib/102869358604761118114"
+      },
+      {
+        "displayName": "이송현",
+        "uri": "https://maps.google.com/maps/contrib/109831619116339538216"
+      },
+      {
+        "displayName": "Brent Seah",
+        "uri": "https://maps.google.com/maps/contrib/112569467590357922461"
+      },
+      {
+        "displayName": "WEILIN PENG",
+        "uri": "https://maps.google.com/maps/contrib/112617776181443762976"
+      }
+    ]
+  },
+  "3456e613-742a-8166-b916-fc0d662dea42": {
+    "placeId": "ChIJc97iKhyZfDUReHAlmt9KMX0",
+    "placeName": "히트커피로스터스 서교",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPDoub3urTpzKT3Dk-yR6ieyZxVA_MpYc-FXUH2vcrK9r5zvwgL63u0yo9HjBL98HFdNDSZfTLaziMjdiEClbfEbyAurQT9vyluQoh0JtU6-wK596VLu6EDbr9yHGOM0Di2TWnH3WtGoNAQ-mw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPRCd157mKJlYodYRZ9Cc_wJJUlInYIB3GTUnvLBdHhyGZTk1ihr1YU8f_UNQ8lpd7XPRczc6jPKzl6OMmMGcaN5267JnkjYinC8ApLUclSxcRfSob7X7DPYjrbNjo3IQEUUExt-EHpsfwg5IABXu2I=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMqx0NQxv1NkZCqloxLNwO-R2c62mR6O9-fjosyNyV5SCX4t6W8J8dQV9Fgel-iuWDTYEPqMFSnBzrrjdIYmRDzDZMHqyK9ej0HJ7eMwnQmd2Egjixx70AqRHu_IfOA5SDBk8S7S6uDsHnaAFs=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOANf0HCK5vZIpFRBbWgQqTdFFqdzv7o-yEFxQTDvoRbRgQBc9Rukn1_z10yuYdOP0F2fm4Rqp3zaQvPUaQ_WU2jgfwrrX2IF62-xBf1iNs522L9cDQrbXaGwRVo_1BCrb0r1u2k43F1ESO=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOi2q9sHKG1lboZLRmVfBwNxRfoM1ctHXoYva9FWGjn66y4z8OCLmWT3UeY9LGKE4VtQR1HFjevBo6ViY2nnZuICfvv8d0vtJvtVrTDN0E4hhCbm6SGEaiXcc4PFnmrW1GlgP_9jut6dYasTt0X0qUZ=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "범코치의 일상",
+        "uri": "https://maps.google.com/maps/contrib/102409794197688162389"
+      },
+      {
+        "displayName": "LU Hsiao-Feng",
+        "uri": "https://maps.google.com/maps/contrib/108616330114328846983"
+      },
+      {
+        "displayName": "林保葭",
+        "uri": "https://maps.google.com/maps/contrib/114030786419627776320"
+      },
+      {
+        "displayName": "조호정",
+        "uri": "https://maps.google.com/maps/contrib/108838961495267256926"
+      },
+      {
+        "displayName": "Anchalee Chantaweaj",
+        "uri": "https://maps.google.com/maps/contrib/109978116388928054955"
+      }
+    ]
+  },
+  "3456e613-742a-8167-bbe7-c86d5dccf82f": {
+    "placeId": "ChIJD-ut99GYfDURQKJHMX0m6a4",
+    "placeName": "로스팅마스터즈 본점",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGyGqDQbJb993TUV-2L7zwgt1aNVW20Xb2gp3-2bwBsLo3frLLaVSJZzKpZu_ZiZrWicVd67KSreXEV-XxYykQWVcm3jxQ0_n0=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPcre4CW2XpB23Zxma2YyoIaPiPU813B6y30cwiI8S5DM43mA7awR_Fm96yuIC1LcQ1TgRCi3IEfuJxDCW8PaNYAdAqcIJ6oZJgKT6zk-inX-Av0UwUv6XvFOZEVUt4APjvz6h_l2t4GIGxBw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMP5KQLXHrOXCZ85YhngPrR67kql0GCe0qrvS5qowNbH3fSqpRLjF6OsY6IxOf3jFGNmi9ztkYbqNDK6qEb-QxNxFAHD2pFxWQEzCG8LqJaP9oOXRQxzSB0ojxO5ZNw30IFE_6WKPejM4SjuPp-oOIZnw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMpfhUfx6GQgwsNRiKbb6jxUe53eOg5FXhXbHBzMQb9cD_YFqYIzylFgbkJQIm6aOckW2Zl12WcKl5C9w8lQoe-UR4VOpHPVYT3xxos5DopF0actavo56WPOpYbqrHYULECyMI6_zeTUWyWuA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMGsewDGTUmdzJBYsC2Tu0S2cIxgGN4wYwZFAbj3CIU6VJRuP8g9u0k4foKdqJbHck5tqcG94B4R3pHcUGFXkDLo33S5O-M4aOUhjegYiZ3uT2b_hdlzjLN0rz3C4yvJ2i9KbbOyw5n4zyGEeA=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "로스팅마스터즈 본점",
+        "uri": "https://maps.google.com/maps/contrib/104162441183739850239"
+      },
+      {
+        "displayName": "Yunhee Nam",
+        "uri": "https://maps.google.com/maps/contrib/100333863946239230211"
+      },
+      {
+        "displayName": "Non Non39 (のんのん)",
+        "uri": "https://maps.google.com/maps/contrib/115567437524978682644"
+      },
+      {
+        "displayName": "Masters Roasting",
+        "uri": "https://maps.google.com/maps/contrib/109745297181587940790"
+      },
+      {
+        "displayName": "IAKOV PAK",
+        "uri": "https://maps.google.com/maps/contrib/103868824186246336228"
+      }
+    ]
+  },
+  "3456e613-742a-8168-a4f1-cc45f6b820d2": {
+    "placeId": "ChIJNRGDt4CjfDURfnQrGrn0rJE",
+    "placeName": "헤베커피",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNXconVpn4gyBNZ_PVV2ZrXWvl6vPqE8EDA3c99o9NQfvD6CziB6xznE2VgHCnfhp95ezCYUX4D8Z-Yhx_iA9Vi9Z0onZ3IbuRj03ae0nhHz8Lvhfmp5ISJdD4nA-0Jgu9ryzh6LjQV5o9rQg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNme6-UVxvVe3l_ZXtuNIkNP5Sqhtz2zfNM8HIi7kYZVHe8onwGYQk-Aaw_J_PzenvR88K2PZEWnW05etj54Aipj0wpSOWcvPx_POnxj_6sHOXO3c0hIxi9qiFNJQ_7CqcsxhpHRMufZqcfnAQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOvN4VJTYoc3zIu84iBADkmme3STzVqTeJmKAE6Q48YYira3xzd0JjBOvBzLEiN3K2AQQeHbO9kkzvKN4z1RtHynGTXMfW70D6LABRgIULoXnAWxmuDZTQJuy3n6BN_tUnqJkkhuFvJvbAx=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPzLlEdWiqdt0aAhGOXDScX_LHSXPFmP-B4FnQI6JJTKq9FX0eEik7iOq3ODLsqHSz8LppMDdKy6ddu_SptQKKY6Dv17-0n2G5HxEgckbCvgo_amyRaL8rV57gEOGQN7-6spKFl69qLZxvR1_s=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMr1AROEx-x5kiRL3mwuuGlM38pTWkmlkD3-ZajvNGbV5i4BodoF3qrVSPKP4ImpH0cHhcJwpA1PqF0BGQtLILUymYNlZzsuN0Im8J6ss_SaCIfSro5QigcZ7JX5fTye2mi5avdVMVcvBRsoos=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "Hyoshin “최효신” Choi",
+        "uri": "https://maps.google.com/maps/contrib/116837340461218774818"
+      },
+      {
+        "displayName": "Kyobin Koo",
+        "uri": "https://maps.google.com/maps/contrib/116967419047356431868"
+      },
+      {
+        "displayName": "Yongsuk Sung",
+        "uri": "https://maps.google.com/maps/contrib/108959025408836147813"
+      },
+      {
+        "displayName": "지나Gina",
+        "uri": "https://maps.google.com/maps/contrib/101192948603330846278"
+      }
+    ]
+  },
+  "3456e613-742a-8169-99e7-f8434bb3c01d": null,
+  "3456e613-742a-816b-901c-e41c2416734d": {
+    "placeId": "ChIJSamNO9iYfDURCIenLHfkW2k",
+    "placeName": "퀜치커피 Quench Coffee",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqFPQuvDl30fQfYvO9k2QZUoroD9KYzrlZ3YUo22BGWleoVGH5z7H_9QWG8GLEGh_R_IMmwrv7us1vInVlWyctUP-kW4Vz_-fpQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPrj1t5x7XsGho3kmxvb5xWOXEd3eNi87CCYYMbECpCF0HgHhMzsp4P5IjcV11ikaTnpqD4QBp6BimQFTMfvzS3Yt7GUX-6sIVAfU4zyBQfHtAUUEJesmPPuHKsuvdnanG6wAYmdJ9PgKEEoCk=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPmAYPSZjqnPxUUQ2fnt80eRejHFfMmEYfuW0Bfj2ef8toOLfSX7KyFj1zdrwOVSzzoN7_QlYSxFhJ_eN7nBUmqXIUaJYTzxJNYOdDeeBQwYTFevpSTFLffPwAR6uVNglqZsXKNhfLtAK0b99C9jyu6=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMsvxU8XXA2dy-5jsxZmC0b6eRbCDRpECF4dZt1Y0_n167LMn-F_dEKosIWLciBwZJ4KRjmkFBEiyx602S10VSmYQzIsPZMW2CoFNYuLg4OQNnmqmL_ntDUauOBs9OFTQhddy6eWSOkCEkxhinlgNxl=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZONelOZtwJSyTAcjsX8ZZUJNZq4CSIXQ2lY0czjC1UwPbQ4pB4zTjhKlUERMhU5Vpkgu064qo-jKwA7rvjxSfsUMxVrzvVUUxQG3v5aSAIq3mbEZKJoTxfekjz-VeQZIsb1nI0wKIxy5hi7EqkKVIFjnA=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "퀜치커피 Quench Coffee",
+        "uri": "https://maps.google.com/maps/contrib/102010754974686746855"
+      },
+      {
+        "displayName": "Ho Yoo",
+        "uri": "https://maps.google.com/maps/contrib/117890331081109595652"
+      },
+      {
+        "displayName": "올리브",
+        "uri": "https://maps.google.com/maps/contrib/102504129803958740366"
+      },
+      {
+        "displayName": "B K",
+        "uri": "https://maps.google.com/maps/contrib/102736215150568380319"
+      }
+    ]
+  },
+  "3456e613-742a-8170-962e-d3f534d87546": {
+    "placeId": "ChIJ0bgZWwCjfDURWIaQ_c_elDw",
+    "placeName": "펠트커피 광화문점",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZM4TiaZ1Up8pWG1c2N83yN1ilG6kC-cA6JrnswqIkkkt4DmisQgfeHBTZgctXhJ6ki-d8MPy5nWM07GQ8c9kzdCrhN2g85EHgmg85USaNa1b_kdN3-3yykEVvopKfIbSONlzCA8SjdacSMSA7uwhqNRKA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNFmYbH8g34XQ_4cd9zgM52akohI8f-LwcbRrSX51ZlrazExSDkEMxDBtYlXs46u9fqwUngqNLs3ETFP4IDNfGyZQtVC5I-a3uvA9hLoQjwuoVEZNivRIedOjFO_Hi86La0UZSGTNxaKwSqJ4jqe4yw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMiUaKO6272CGUhyu7vT2RzLPkI9i9Pau6CWR-bzWKI6bM_I0Uu9uExCGY-qxOrUYceIVOFrBedyXzrLf-11c2OX2fS7wCZOHPRvVhUS9b14dObG4WL0YaBhMc2WlzMEGvLAd6K6KXbnvwvDJFRyHG5qg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN5IimTpoS4-LmRk2BNvj8OZ3JxD3kyisBHY1Qqnou-Q7KvdNv3yYTJciPX9bwF9A_ti9OmS8LPMomValDDqLVMMfHC9j-7nq7RKj-CVIxs38piyJwXC83P3l-VTh8MIsOL9eNVWmB3cZlY8W_6Biw7=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPS9MHkzyV_MCVvHrIU8paKhx5_QD0dxO_1QOnR7yFLHlgGujcTJkC8NKf3v9sUcqwZXv_FJAWrRMeWUlpsELJxvUO9XIqXxsekVsst1gvGAUkFSh-0UfLAM26yhkpNtoUK8F-rwXlV1PIB=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "EJ l",
+        "uri": "https://maps.google.com/maps/contrib/105490286672075104016"
+      },
+      {
+        "displayName": "PBHQ",
+        "uri": "https://maps.google.com/maps/contrib/100748775284369640799"
+      },
+      {
+        "displayName": "규규",
+        "uri": "https://maps.google.com/maps/contrib/111064026983487537709"
+      },
+      {
+        "displayName": "siro75",
+        "uri": "https://maps.google.com/maps/contrib/117148674458184446110"
+      }
+    ]
+  },
+  "3456e613-742a-817c-b986-dcc0c7945e00": {
+    "placeId": "ChIJVTXXSwCjfDURdm7gHzwehyE",
+    "placeName": "테라로사 국립현대미술관서울점",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOb0J7etstQ0AZL71MxwWcwFl2lEo08E1DkNxgfHTtu_Zw4vocVXtPA-aqLhXACDxDNUUxUFcMI9XwyLOBBaifeWXtruOw-olKbNGSHf8JS7Q4JV4UMBN9evuhNKCzGA5ezgVV1vBUTarBBgcaqGH09mA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOXIvEucNdajb6r2l5pX6g_3rvuEDRQD8ST2KgkC_VJ-wN7xEqo51NnQZ7Zcy-7VnKoIHvmuVO1I1Pd3FqLldKlWOOqIrg7V-UGW5CIWW2Qo0lygNkrdves3Km80H6SPK0k1m_aVJ2Gs6eF0vdmnkWUIA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPnPmjw6KD2c9CM7FEfQU7ES_DOqFM1Eqp2ClN-LVbY0MM3K27Lw-u4oZFOwEERXtOXRD7hurSNs8qdS4bo9BXb5lHwq4laOL6NUcwQDDPZKTzUbhGr9yc2RvVzhxo-IWMHlR1waMTzHEkxBtaC9K6g=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOA9lN6Unq_2cQgTombLhZDUjBWEjz0KHD4h_bQLqxL8Td8PNSqeCVGTfl4aQJU6fbyw4SBmF2b2QWjNt3X-eAjX02WgxXTxYfXZXbdDMrsHTgBzuvqLOfAkfZykqD7GbdL_Lp-NKIyqWhGQw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOgb4u3Oi4ENeiLnWLZm-aTIRTJ8cLLyPlLiKBG6D2ng4garBv_8_k8e4jhVFUmDebCywlZ_kNY2xJsXK5t5jIxqDsvuvFgsUveOwBSimv4e8QW2qSyS7P0kkThp5i8dxesRtQ4mry2ku7V1-4QAeA_Ag=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "이동현 (커넥터리)",
+        "uri": "https://maps.google.com/maps/contrib/117240882341854953168"
+      },
+      {
+        "displayName": "ADEN",
+        "uri": "https://maps.google.com/maps/contrib/101083200750962039989"
+      },
+      {
+        "displayName": "김경실",
+        "uri": "https://maps.google.com/maps/contrib/102967200202073535718"
+      },
+      {
+        "displayName": "MJ",
+        "uri": "https://maps.google.com/maps/contrib/112976572875988699111"
+      }
+    ]
+  },
+  "3456e613-742a-8182-960e-e41c0092839c": {
+    "placeId": "ChIJr8r3XtSYfDURLs-hbLaOdow",
+    "placeName": "빈브라더스 합정",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqH7VejaAV6jr3AUqMojd_q56u0AZJ9mLMg60oAy4bnWWi5s_1Q7D8uTMCkZloJ3YLfrWTJg-mEQQg0Tnx0Ad7MjzoBd2gDh8Dk=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqFgKhxEQmHJS7MnB-Qf7_gXS1dQcoC43aMQxbwPXWm0HS1lTMJ3m3ep629Njxji_WcIWLhkVwEFwvQ_xyRwijePSpzoCnU434I=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPFvT6ogRQfKBhmClIDhD-SxYqBrAWTg5ddm4H5gTaSnpCs7AfrWeKkeD4GpHHlm3Xbbzd0ZQOR7mcEihZIXbNOyhQ4dU2-vBVl72nOvHAQukPsQPP3VMWSxtYwI55nQav0EJY34vLMGPZanw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOvVdwtOo02RtVh0lTHMRTjuYBBc9jLlRGBjOlKRuL58U93fFZhhfrK1vUNEiR2eTmZDalbRYtbaYc3MBl-bLtHaWCoi_wXDEB-mWnNfbnK8lX8TJQfAgD043zKi27XyGv7smKYho00PcGHM6mwkGIW7Q=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNEqeGV5iXs6fSxf6dtMoqJOcyjpfLGr7a0ObjUWpjG9_ALa1UaaIlHLHt61zkmwrjVAUA26aZvVzpu1SLF5IHzbYNykPU_t3wEQ278R2u9wUoKE4aRo9TizNUTOjkIhBF0uBC9VtIun13okPj6e7a2Nw=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "빈브라더스 합정",
+        "uri": "https://maps.google.com/maps/contrib/103211174331699535692"
+      },
+      {
+        "displayName": "ruin Sung Mean Pae",
+        "uri": "https://maps.google.com/maps/contrib/102778409927121337507"
+      },
+      {
+        "displayName": "moon-seock chung",
+        "uri": "https://maps.google.com/maps/contrib/104854992064389793437"
+      },
+      {
+        "displayName": "두두보멩",
+        "uri": "https://maps.google.com/maps/contrib/102990377736972576945"
+      }
+    ]
+  },
+  "3456e613-742a-8184-94c5-f50be5356e64": {
+    "placeId": "ChIJ63MygdyZfDURur0gAqslRF8",
+    "placeName": "망원 지튼",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqHU69RXln7bbG3wQTiv9jHFLjaPq-oCH5G2g4Pup7KWOqDQgqb4_H5h_VBhE11ECYe4tIB1FAFVkFj-XaDG4R3IIFfMSnQRFak=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqERLMLwPTrWhAOw8rKQ2ySKLRM3IU-Laa4chG_neePs-W6H-T_9BDpOgYZLSI1oU9zpNOK4ap5G5038ZMIeeC3D5I34aUgiBNE=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNttYFN7tEYN6o36EGxODk3HQYXWOMKwbKUIh9CZasyIO4iultBqdfWMQQeblS3FIBvwEiaSzY2vkUdupAOGZqlaW1BeyQz67Vyu67ScXQTCTZLggGhndNFARfttjjSxR0sKqmWs0cqtwF73Zs=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPjxZ7QTV5rhvAaJn8Jnj9UFb0C0hgA-jMqPhnkyevI4PGhmE1o7js4AbCawPQJb85rXLl6KNpJgaFeeRgzbnk8vW1TDW9QsdQrLUTDyS-TKjepV_7q59_ys0EINmeS7Cz5CyyRNa9hNpNrNPGhYwPWHQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNEMkdD_--w_Kr5ldW0aCayXgIqCpwzxHjT6aXCxB_Gi-bdJivW94NgrkYkRsmSY39rz2Cq_MoKQ7UX3N3OvmpnGVz8B6-3d3zoL3fVvKyhZwLQOZrxxMnPd4F1OPJe2avs4HIrJHBmkgMYogkroTG8gQ=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "망원 지튼",
+        "uri": "https://maps.google.com/maps/contrib/104684183525583287497"
+      },
+      {
+        "displayName": "박정환",
+        "uri": "https://maps.google.com/maps/contrib/100988524057110604884"
+      },
+      {
+        "displayName": "장유민",
+        "uri": "https://maps.google.com/maps/contrib/109618683476606217821"
+      }
+    ]
+  },
+  "3456e613-742a-8189-b998-eaeabad432e2": {
+    "placeId": "ChIJK05lru6YfDUR22H8d3bQr58",
+    "placeName": "커피 리브레 연남점",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGMMEHOipREJd-v-hrxQf0O99vcnnlsoiBChHLi2aMApVzPZf-GR_QZu7Gp6lg7g151J7BOo--BaPfmIMvIQXW_ver_VG60SbM=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqHxaT1RrmZ-Xh0PEjsawZTcZTsirw5kZHARgqm7ZxshiQrBl5tOLKsI6DQmrBaRY4uY4SD-YI9x74u-NPnh602lOrXaOyNCFx8=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqFzsMNE4Ls5czIiYf8lcTQwFFmSwjmskeNWHXPLsxXJVfg8Xw5Lglbr4iLWSuE22FgimLlKnTNlbB5yWYmgq9WQdkZCreufNUo=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOuVSXU5UfIwB0rhTA_oTs_mz00FmcDoitlYDg4qSAvR8mzoqeR76YXyJ-r-S8DsA-xhwvSfP0Bhw5LCCdfoVT57YntMxU5EsxgWbhorNlP_ohN70AIogdVmGNhg7DCswg1k50K6odYs6mxkAk=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNYZPn95Sn4ESg6nJvHwnQ-LoJTMLsFp2VLB4TxZEX4ZPUIqv9fzmbuCjl60tTw0C7dQ1ehjqo1lrYKnL-k9uwgpeUUEGTwlG7HVqGuNX2Qwj1wkdZVU_YJ4QTbZ9P_9x5dVY1WsxWWqmu2ezY=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "커피 리브레 연남점",
+        "uri": "https://maps.google.com/maps/contrib/100188394623092256534"
+      },
+      {
+        "displayName": "CY S",
+        "uri": "https://maps.google.com/maps/contrib/100734868837257853242"
+      },
+      {
+        "displayName": "jang ramul",
+        "uri": "https://maps.google.com/maps/contrib/103608043953656784658"
+      }
+    ]
+  },
+  "3456e613-742a-818e-a791-ec118760640d": {
+    "placeId": "ChIJz78QLgCjfDUREMXvLv4PhEA",
+    "placeName": "Leesar Coffee Jongno 리사르커피 종로",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZM5RvPTtATC0dwVeDWV4jZYhfeiyu4EwCVqNTIycTZLU04_vxi4i1OzN5zfgD6NdHMC3Uy6IZ47bh6qecY_4Vz8hO15I9w8rlZb-itnbhDcZt2CuLbXY80klpuMLOQy7GWfDd0MWk6dYPNwEuQ=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqHCa6Mh8Vm6_RjLHCUcDiQTyq0q5brjgAQhNKeLxGTqOBHY-n1vcTSAR2zr7IU8wticE9Hy8lEpTIsya7m1C0TVzBzdEXVFCdg=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqEfPZ012Icw0rhMQ4YDnqq0fEKBoVrouNgcryDL05mpKrPz9ztYWmxQGsZzHOKH_vVCbOkOQkEBSZdo2Xwjaavl73OVuP7FGac=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqF2j9nCf0DKr-6DNHRUf4F6XwYbo9Tla0UigX-0zSc6D4QDE-pWiEwCE9iETjqXodL-NPCA45tkubZJgI2k2PK-7mWNOJnJ1r4=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqEql8vs9tN5A-Xgnnz9eGR2oESQ5UrJlOpJ8wbR1U9qhVj1axTknYkuP0_cb6tD5Xsf8AtJRw53bbdwyhZHahBz0cIc3U_MuTE=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "kang kang",
+        "uri": "https://maps.google.com/maps/contrib/107641118937651317189"
+      },
+      {
+        "displayName": "Leesar Coffee Jongno 리사르커피 종로",
+        "uri": "https://maps.google.com/maps/contrib/111421352271308849915"
+      }
+    ]
+  },
+  "3456e613-742a-8192-aec1-d19b274b78b9": {
+    "placeId": "ChIJt2c4rrejfDURWMlFqWJnKlQ",
+    "placeName": "10스퀘어 남산",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqEy68BzN32eUUyD2vQ2YKiTuc8bA-9ARBt-j6UV6e3JAfnxSV8-jfPyIRBomNOC0xZfKxUkpz9u8iWbVk9177uA-DxKpXuVWkI=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqHZvJmgptZyF6QgHu9zDW0Ry3DNL5SoGUYxTnx_hLYIeNFkb2JP2esJJLMXlMxjYUIMURv6FMfiod6MFMy6Ob3Jg02bYfTcyGI=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZM6vPR5kq5r5mifvRl0APr5OPOVryL-FeLXtqMaBfwSZnUyAypiiQsvsQAUaLt2OF7AmDpBpt3aUmElEzoH4xZtQIW5kBIPW-8fdEBMvYam_n79LR_HPbhWJGS0NLq-Sg3t6VDMANaFEwZC=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMaeYOdZORelo4aK6k7qrsueeA7s7AzQOZvst2w4Fb2UP-tST1bT-NLpyMKYByxCPbIUpA7QuaakcrD8LEl34bGPqbkTA3pMHdXZ588_S0-dXvh_BGVC19X8fMxM9mj2oVnj8XUscM7OtenbruOZ5FhMA=s4800-w757",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPU2hvpcoeOcBDT2Dn-CWi9EIGpev3OKu1qd9WtpoaVGaN8r9rG9arvCFPBpd9rxYhETY7FlXGGY1dSAiu5rUPAOTTjE1csL1H_dDyRtz139tI6Fc0Ysdo8iIquuiXVXeBtniC280oWjw92MnoPDYaU=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "10스퀘어 남산",
+        "uri": "https://maps.google.com/maps/contrib/100160772982925886311"
+      },
+      {
+        "displayName": "G S",
+        "uri": "https://maps.google.com/maps/contrib/114414547499468359326"
+      },
+      {
+        "displayName": "J Park",
+        "uri": "https://maps.google.com/maps/contrib/105302015867721389336"
+      },
+      {
+        "displayName": "大村優介",
+        "uri": "https://maps.google.com/maps/contrib/117318016048129172153"
+      }
+    ]
+  },
+  "3456e613-742a-8198-bb10-d841006daf57": {
+    "placeId": "ChIJRZfgcQ-jfDURPAeCBYaIr88",
+    "placeName": "노띵커피 시청점",
+    "photoUris": [],
+    "attributions": []
+  },
+  "3456e613-742a-819b-93ff-c4e48531760e": {
+    "placeId": "ChIJF6jF_32jfDUR-m6KRtuHEoM",
+    "placeName": "섹터커피 충무로점",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOe7IBy25Y9LS2R6ecttPbvDAXIz9mN9gErwTqCnPQAfiIjXklqMcYLUtMDhIPHRNLv1oqTQLLxSDHJRWPzLnKUUFRFym1v25s6Ew0TyP-8tfhfYgI9Cooapws00ph0zGooCjDrake_uV1v=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPYFSGswk1-tkTDeP2HaWqmsPBS3fPbPGBDO-i6vr1C90Z0cyjh-DgEACNaVEhl18DF33Z8OrrahWUVLZSMXpU8bgjpNe6gJnj3JbH8DO3kqF2Ed5sAcl9PrDzJFd6q57f_ICu7f1skN-iJ6r4=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNWQakFtptCyAeFQtyNWRK_yXP--5PZO3SwNv8YyZF8QFF7b9JtPeFa3SIYsHy8xl5P9gZQkoqZVam61usNM_pdviy003xxvo0NYu8lIbFbM-Gto5dH4NpcrwpayzR5xzi8wXBBDQBVe4cq=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZM72A_f4pbn0ugcDmqeplryyok0CFRJs5aPTge8lB0FU3rUv55ZdXDDlwzBP8SDD51oWUrQW-NjW-mtOoYUkmPYMFwHVcUzcx0bK5HPQYgEn65dJJDiwspdCZEB1X0gqknZktBjkkvjWO0l2w=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOwmK3A_AICyXSE7JSldE3gDn07WvkaJjMLP9HqOQUKUBHbBZwcFbrShDNtyMXTn8YTXELRwYoSqMLaDl20XBb6HhnpVSszVDTzdzT2Oyg9-IwU1r0D2-w0DUkEcL_nN4qbvCIjJsM3hAVyuvWcZPd9_g=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "jihyon bae",
+        "uri": "https://maps.google.com/maps/contrib/112992327282736445583"
+      },
+      {
+        "displayName": "짱이야",
+        "uri": "https://maps.google.com/maps/contrib/114699963417588940889"
+      },
+      {
+        "displayName": "Tomas G",
+        "uri": "https://maps.google.com/maps/contrib/100489612856131015301"
+      },
+      {
+        "displayName": "Kyuwon Lee",
+        "uri": "https://maps.google.com/maps/contrib/110778779454043925617"
+      },
+      {
+        "displayName": "Pichanun Boonpromgul",
+        "uri": "https://maps.google.com/maps/contrib/118145485622453747582"
+      }
+    ]
+  },
+  "3456e613-742a-819d-87b0-cb05eaed1ce5": {
+    "placeId": "ChIJG6cSr1ujfDUR0jc5D-6ZHao",
+    "placeName": "블루보틀 광화문 카페",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMu4EcMAUPJv9kNTxt3k9VPcE3xw9YhfaQJJMlNI6T1bQC0WM7Ie6MOXObEMono6gGWg2s36en44SbSY8WNiaN0pldW7LKcIPpArGX8RcQJmRjgV0uaFPOxU1EM8s0DWiNLR6NwbHpyVeKLysM=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNYTDonMBKgk9EhCIqg19484Ng2yFlSsWyO6WKPmRUyE2wZzTE5AGUOyjwR7QusMvjupbeWrLz8vnM7fhbwOU43F0fWJoNH2VInDtenEajIJb3__YmPtsTXkng3hjHxvMofvKwcmJWY4MMJiHk=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOyRMlQ2BOkOajTVlvwbDi1xByol_tmHR8X8DsvIYlekrVka0gy9C82foI5gDUF0ivBU7Usou-ugrJyJXI-uj5ZKSfflb0snP5o3PjJIW2Zd_wvWmTRRdqRQtiruH1bnIzvjlqLCUk8KsgK-Xl2RpFbng=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNupoUThCrek1s2NYGA3qknWsKwBOfRmuyrS8E1oxy3BULv4Uq4MlQTlL6BmweU6FroDqiVoqSGcP9HlPen_aXlJ7USCPkNhSonVAKlFCMXYTIHqUCbB_6C1pGP2GloZMRqS7tpNMdybUYwv-Dwl4Px=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMc4tHyRC-wYGi8K_QThb6TI77mHmkdeisI2KVCC7Sxb1hr2NVCtMKXDHcJkSr2hrkbIC6tIHop_08uyO2LXTrsSJAc54lxma0ZjlYI5tOX3cdO71B9h4bYE1tM-ATtft741QCzECqIGS7mI9c=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "Minki Jeon",
+        "uri": "https://maps.google.com/maps/contrib/117682195379940907161"
+      },
+      {
+        "displayName": "rosenie",
+        "uri": "https://maps.google.com/maps/contrib/107541774454123623996"
+      },
+      {
+        "displayName": "PBHQ",
+        "uri": "https://maps.google.com/maps/contrib/100748775284369640799"
+      },
+      {
+        "displayName": "김혜정",
+        "uri": "https://maps.google.com/maps/contrib/116873594925716763421"
+      },
+      {
+        "displayName": "juju1 1117",
+        "uri": "https://maps.google.com/maps/contrib/115193856539822311490"
+      }
+    ]
+  },
+  "3456e613-742a-81a4-a35a-cfc0bd4c8aec": {
+    "placeId": "ChIJf_dIdaKjfDURXj1_URueKAE",
+    "placeName": "커피 그래 Coffee Gre",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO-KO_p-yiiYdw4fXxXp9MR3Fu_nSvQNv6vr2wFyKisy8ct_ZFGuTvp_HFuCruSVwC37c69hh5Zt7tvDDp6XNZmdDcYM0hffXFmfemktjELbF4uo5uCPZKo0_ngtBJGRHPM8Xg3CN13V8omPNY=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPsz10dcdsVBcsxbPp3r-McVVu8lu_tilOM--98tL-V9iu5r9OCzdpoDALejW1ztYq2ZnsUXo1eZcrjymdfvF1Y9pQyOpb6wAXOSbEll9pVV0WxLDF3IRrfwEPYqEPKLpCuoOXPeMXVQ8Wb=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPowr82IVExNest0bz9vqAkkuMMsPYRtqj8AOhitvpdOcFbCYBdYnRN8U_ByS5wfkX4jj-91yZeiyTdWCV0ufJ8o0YOY3LMJxcDqY337VnafnGq__jFWwgyBu6bdpT4htAMDK-Qf9y-Xj5fg5o=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNnvFyRVE4T2Dn8WRaiOXDvm12yhCT52QIdasF1GjY2B9oLvp4_muMGEgwN1mH4Hg6abayMcBzfJtp2rfWTEAuE5BUgTgqtFNuhiUhMdwXZxTfQS_2lma6yMlKrJkHVRGm8_Tzn2Jo2OOF63Wo=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNY0HcVqxZgoCdcXq3f95mjZa6oL7n6JyuRyon5PUHIPnLpXCxBt_p91K7-_fpqdf5STFKkRw3BEWznrQE5kxR7owLpuXECNL3Pi25KNMNhBUmJ7R9P6gFnnUb1DpGzYSU474OC5MXSOy-J=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "stepanorama",
+        "uri": "https://maps.google.com/maps/contrib/101365978953489823828"
+      },
+      {
+        "displayName": "Yeonju Im",
+        "uri": "https://maps.google.com/maps/contrib/105073872421360972186"
+      },
+      {
+        "displayName": "Vivian Chen",
+        "uri": "https://maps.google.com/maps/contrib/113780243021424332188"
+      },
+      {
+        "displayName": "이동현 (커넥터리)",
+        "uri": "https://maps.google.com/maps/contrib/117240882341854953168"
+      }
+    ]
+  },
+  "3456e613-742a-81aa-870b-e8492d89a078": {
+    "placeId": "ChIJQZjPUiSZfDURSaJwBA3kOdA",
+    "placeName": "Rutile",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMcOxLjdPHPLcUHBAnpOzLQYTUvnHK2JV5yZw9TqvX0Qrj1oeDCk6YOZsrG_7DukG6dGB9paKWrpWrKXkZ4JUc75cmGAmF0RlXKCNhLgjB7r9WkRjS8c_qtMMAT3GxhuW6YEWJJf2BSDsnGgtXy7jQs=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqHA83D8XptyZBxXOMfU9EEffBdVJiZhnzfk84Ai_6nYtLC5d5JMfo-FJ-WBfQRwAN3XI5j-ESYu_T_YmbkOqlvdEynSII3_Asw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOV2s0dbvzfVH3da9YPSbFagOAIYUUJRn1-as7oBkK8uOgCJKq4S7-8xwGjwf8_yOkZ_DsrmJRlp-OiibpXqEExEcHzSsidpayUsfEMPnnQyO7C1JrpzM4qD2aFST2wDi5PhbA4FXeyAvpvom9Mn9tzuQ=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqGjeWxFKPpNiB-GBR3dbR4NNMVTm5TUIyHd4NSoKe3bnXbtJ4-3LjrrRW2AuW7S1HMO_0i_42u8J98lRDMTwllhzihedxYuDco=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqFamAft6fUWCgVEz0Hevujb6al6zFSy5Zjvjp0LdF3xFcmmOuNp-_l_Cw3igEbxAVEBaWOFG8v-X-k5Os5g6ogt0lwco6GfhXA=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "유영상",
+        "uri": "https://maps.google.com/maps/contrib/117446042587647161743"
+      },
+      {
+        "displayName": "Rutile",
+        "uri": "https://maps.google.com/maps/contrib/105257275143129772496"
+      }
+    ]
+  },
+  "3456e613-742a-81ac-99c2-d659d9f5c674": {
+    "placeId": "ChIJI6FKRTGjfDURniM2Z92eWjM",
+    "placeName": "카페 결",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqFhJgLzpZkTp6ldS0oCej4TTBjRry1EgjF5D7Uf2jU0z19gcHPMZC_OypnUBhOD8de9ky3gOzKt4--d-4QxxWdRnuSBr9BOYvc=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqFsM7rt0fCYZ6osARA16QO-6Tg8g27Qncyiusr4GX2fnXqTofM30ES7DvM1n06x4efXq6Cv1BVuSKIY5BgApPPTCLkrAKQEN1s=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPbeVubDuZiZh_0Zsm051s0qw2N3pWViUEd7nTK9BvIYYvkG2UbTQBrVMmSnsdWV8PEMbYCzYy0FLNM6Ux3MjyQG3gkQ3zkuLGE8F5bUG0PddqMvsk7sdLbeXdzBnMVJvYZz2_C--3-Y9_XxC_FJ53x=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMNAP9N8uDw2w1FjYLrqtrv6MXcAc7B_i1ad9LEgTt4zHL4VUWiv6z9SdIr7m6StQ9N0NpDXD_OyAEkJKpKrwOtsKF42pZklInR-6kh7ndCaGr2arOdP3P7ESZaU0grAixBImpbPEpUAT66H4WPjGmynA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN9WQzFEY6HghceLxaLRzceg5Yk9pByWXhNnNJdG_iR1dJd_MEq9sLGJ8Xdhoqwrt09T-fCIbSDH9Dpd5Gb5B2LDnkX6HgvCL8NRIzQDcgBI6G3wNbskKseZ9ps4QXdYTmPYgPKVfEUgAs_-2UQMESc=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "카페 결",
+        "uri": "https://maps.google.com/maps/contrib/109990308733987235877"
+      },
+      {
+        "displayName": "Nguyen Tong (Win)",
+        "uri": "https://maps.google.com/maps/contrib/117420533765349918010"
+      },
+      {
+        "displayName": "Eunho Choi",
+        "uri": "https://maps.google.com/maps/contrib/110027581853732752863"
+      }
+    ]
+  },
+  "3456e613-742a-81b3-a1ba-c4fdfeb25956": {
+    "placeId": "ChIJtxLQdtijfDURX44uncpL7KE",
+    "placeName": "벌새",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGdqlkD2as_qw73O_SeO84iAxT_A6Xr03On7UiWjssW35N1Jio0j-UoocPSKPwI1WyHJlfLWU3RyVkyb6yH4Ybb5keVGXc2uEU=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqE2JRBcs_oZJdxWjTsYUh9BmGibXWw07SBomxQaDTIp1kGn8BwGgC6lF14tk0zCestE4DxTY7D9RviVWX0VBp_hp4nO4Bt-dNE=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMsW-1F9aIagLxrJ6BQZ0rQ1d5_nx3SmAco99fihHjGKFxQgx5Yai_iURsAooW22c8BWNsxaxXr6PxHrhmUg1X_m8F5atTwVfOyXmJWFr0XIhRLQNsh228pr_PZOhB8vzErQDiv59CgI7eE7_A=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNroX-rKwbOKCL0B5SfiVPYOiWnRS00aRHe7-r8Hsq-sYbtk1p23IGDvwS4SA5IlSpjyiWJZZpC1LOaG-P5vDZ_8WWGanW-EN4r2PAqecfwcjRe8LC4TSOKrxbdqFCHYwLU2u6RSAJpdMyKknCtYagdkQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMjIUpEHoAc6KQKyEC-BWJmVSsFE2DHGb2v7KRCDWwacgg9DKZSogDzfdXG7pRXOWmfMEwP6pdMED-2A5HTTRcz8j8na-pFiIzAbY6-eekoAd257PstIY0rR9AcnvPdm89y5r0_re64JyYznyJrEPk4=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "벌새",
+        "uri": "https://maps.google.com/maps/contrib/117605988042720754281"
+      },
+      {
+        "displayName": "Newjin",
+        "uri": "https://maps.google.com/maps/contrib/105446364100325684675"
+      },
+      {
+        "displayName": "siro75",
+        "uri": "https://maps.google.com/maps/contrib/117148674458184446110"
+      },
+      {
+        "displayName": "アオヤマアオヤマ",
+        "uri": "https://maps.google.com/maps/contrib/101123761628381978757"
+      }
+    ]
+  },
+  "3456e613-742a-81b4-903d-ea20420b9a3f": {
+    "placeId": "ChIJsbevhOmifDURHdAQsf3-O2Y",
+    "placeName": "커피친구",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN62RQ1FnwvGKUmwr2fz9oqNtG5yj66k2NZPOdDAfxP3dr1j2xdu5liLLeGrienmwhFgRoKNbE9YMKCVFJagsN-12bdWsGIZjc96rL-UtLkgbWD1XSds3DArBnFPi0HEFpKJqnb4wCYh8qji9k=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN1jnggu9Zs0fJae8gEG30J3Nepv4z0lQq7yD18iKLkFfbjyE5DZX8Xc6KCj4vYnMMtzoYbCiOyuP3ARJIHYjEKu4fkI0N-rItno49ZeAj0uQYjVDV2zjwLLpd1itBixDV6UZO3rMZGUZiNpNM=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNic454bi0eb2sJU2GOZZoxkKuRDjQDu6aGvWWq5dOU4YO1c3bnydcCwQjGVKlMhJfLVrb8hEPBdQ3JXsohAlxuDiHm3SZdMm3W-5gb_pDYMZ4ElD9um6rhh8uWy_V6g7fSd7kbVOUZjfT7JH_7rknAxg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPC-87GCd4AUIKK2cUT2TyeWgly0Oz5CJcwC9asRCSZtecku4A-ufvZDeAKpy_UGnG3hNE9yXp2AItLYzOmM-DiYlToUMpk9qFlxDLXwbxLZr9JTYYDa2_Yh9u6kS4IEpZ5JqpCEKZI-nlYmRw4ch0bkw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOk8BXQJdcVC4JjxvxCWfJOizK5RaJe8Y0HeDq62P-PVQB10f-_n1wDBWEY-voZSTBG2TpwpQ6fw6d2SyFk1pNTz7NoLGkNqh7HPjrT4Gg5ikaZmZ0l4oD1fpcXSlyZYq5TZBzxhUDi8UVK=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "De La",
+        "uri": "https://maps.google.com/maps/contrib/106119554221740690788"
+      },
+      {
+        "displayName": "Tanuja Bhat",
+        "uri": "https://maps.google.com/maps/contrib/114150979507454066144"
+      },
+      {
+        "displayName": "Jackie H Lim",
+        "uri": "https://maps.google.com/maps/contrib/104350919687035955949"
+      },
+      {
+        "displayName": "eofish",
+        "uri": "https://maps.google.com/maps/contrib/111441020920432035855"
+      },
+      {
+        "displayName": "un promeneur solitaire",
+        "uri": "https://maps.google.com/maps/contrib/100309870201186518618"
+      }
+    ]
+  },
+  "3456e613-742a-81ba-832d-c748b394872e": {
+    "placeId": "ChIJRZfgcQ-jfDURPAeCBYaIr88",
+    "placeName": "노띵커피 시청점",
+    "photoUris": [],
+    "attributions": []
+  },
+  "3456e613-742a-81c3-b6ef-fdf02f2327f3": {
+    "placeId": "ChIJ8Q0DJq6jfDURNLzB5mKz2hs",
+    "placeName": "P3R:C COFFEE 펄시커피",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGyGv3z6Trbzt93q6uUM78k-BooS_avatW5R2pszRA1cNpzRohts1PU3ned8AnUVBTLT1M97Np0orWpYZ9tkbmNX4ER2GAkV98=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqGcdoLXUu0B9AJGDEqEXMEe3cSwVwPpKvdOWCccOJZ6Q9j_1ffAyfhoRBThx59VFnFuOqSL4w22LZGgRs1t9a64QziRjPKAcGo=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNggF1BbaFtQGHCOMD-ykoMJ-WnDAPHXDkNkBZ63zqw1eRBxL7zqtebPgHnRPzl6PuXORhYHVaCEIF-FFyB4GnkJ1Qkxk0y9e4L_NJ9jo7lym7PaVcv5Zae62cC_DmgsdQ0IxYFfaFGKBhDa-Nb3BqkYg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO73PMI8auTv38bnm77Tg08IXCjC2C18RlIjuySXm03icFnci6NV6GK_6sTrmNmwEX8_Soz7StRR7uYEfoZ6qcv3q9sZiZd_sKcwwuoJsFJxg2gvPBwVunsl_ldunMyf_jLrmxcQJ2wmxhq21f9HO4Dew=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMfzurgzuPDbXr5Tb-H3kfD_QbsskIOrXoreqewFSuQ1Eud-J-AdEJ8tl02XUiVGbUZcz_Y0mTwyX__i-33JsPKI4Nudph9kAw6mAQWJhJQRMt-VJ1EbFWVRpvHiIFW69laoTX2dAnm-g8RV3aTc5KX=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "펄시커피",
+        "uri": "https://maps.google.com/maps/contrib/104148683268642581574"
+      },
+      {
+        "displayName": "darren Jung",
+        "uri": "https://maps.google.com/maps/contrib/102251462737260712049"
+      },
+      {
+        "displayName": "damnstew",
+        "uri": "https://maps.google.com/maps/contrib/100360488290174361333"
+      }
+    ]
+  },
+  "3456e613-742a-81cf-99c5-c3dd1135f656": {
+    "placeId": "ChIJhRZcnnOjfDURuMDQe5XSOa8",
+    "placeName": "블루보틀 삼청 카페",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNkjHFR2a7_qMc0XiZI_4iR5qDTNQvU0pUELbQQkyyHSPBqwrmcw7gq41Fc7l2Y4wd6h4mNu5Zs1qwS-NuUa9iAGHH46LAlN-lyV_-HeOlu_GbR3lQ--5eDYSFIVMZVq8HYdAH2w2ANPlwhLtK6TgobZw=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMqmZzrjEriDS4lRCNLPMzujSRPkh2GaV2ooOsNUhZo0Mea5XeVz3dYhP_bJulKDUlv0XF3CgiQ20HegsUscC3retmDSsfMUwaR-opNQiWBEwi4mRPBZYAu9STH0tV_N4zR2qXU0beHudC4iKQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZP4rlsjxH7P-7rJTP55m168D2mtfTkyYxSNKqgcVAo4l4xjjOrrSRr3qBBcd0qWdpAW8WCHHzn11Hh02RBujX2OGgjPdT4Ybk7YI_yrTprOr6YKBKtCzOFS4grfGtu87vRTnks3oBF_TAVzUuWUtDnDEQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPBf3ohKUC986HJqzRr52kdoegJT0kFopKTaSJ0xjXS0P_2f-mkyQgNMEiIq1W0a7nmRGXmb21OxdiIhSpQv420HGkoZ7EC0LIbMfIRmx18AIGDRX00_qWhF9QI4Ds4w9ggQtvjlUchULdipUUg_hTQ4A=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNC4ybh1LSce3U-NgJ1PLlXpAvCR1XKPkh4iwUli_OwxaoR-9_uLu1zXmmXehd5LdLUIa1EfwFt41bFFoIWzu9y7TkqIQu5Eis6WKa5u68SsqjDD4TbkyS5LyG4q0G4132xUALZ2uYL1YiATt0kM07OBw=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "루나루이",
+        "uri": "https://maps.google.com/maps/contrib/102265699602969609145"
+      },
+      {
+        "displayName": "HA KWON",
+        "uri": "https://maps.google.com/maps/contrib/109161350980383316858"
+      },
+      {
+        "displayName": "WenHuei Chen",
+        "uri": "https://maps.google.com/maps/contrib/111271951369724601076"
+      },
+      {
+        "displayName": "HUN KIM",
+        "uri": "https://maps.google.com/maps/contrib/104490842568215655362"
+      },
+      {
+        "displayName": "Eon Wang",
+        "uri": "https://maps.google.com/maps/contrib/104092365072111774209"
+      }
+    ]
+  },
+  "3456e613-742a-81d3-ba40-cb1b75933052": {
+    "placeId": "ChIJ79YlKZejfDURWiHCXwkTdbk",
+    "placeName": "보현커피 (BO HYUN Coffee)",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqEZpwb53dht3D7erbmyf6aXHOApAhnrqNGDQ4eBcRcJEe-PcgNo1mo_QknJxFRcG84x0F4jDeL7TekdTzcJqy7TIVL2kaesSWM=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO5rPVvBHQGuSv1EreGYiNKn1TPcldKn54NmNdwTUwwcre5TtY7Bfvmw5wf28ZW_9nGnFJDFU3bRVEilYBtPaWe6E7oBKFHzMsXQxfkb7pCZNzuBQRKMFrPzAUY5vZQIQeD7yyXklG19pbXy9w=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOq5zvrAXnKmEZx-j9fofU66kmyuqvUu5NJ4QtLHpaujjrtH4jnJJXaVZvBM3vTz53hlldAMUJeItJUYyO2CbNeMhK_YfGwirpZ-GE-IKUS5gvTeA2zdUZR27Yc15zHxZgRsvMk8Yh2GJtEjYQ8wxPQ=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqFemRY_iM0drmwxdotu4V5ccmZPfYDMUTjVTzslDOfjCPe3eL-uTDjS8pwFvZD1RQPDtRZawZ59diNTZcZcame2NFhtdOqxceA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPajCeoAWCkwaowTpIj-CcKCmSbKYXIIa2rYzE-h1vo548n38WNEIJO1u9VVSr3dRVP_6qNHpuI-ICH5YCRTlI7sc1Csb1y_uozsKzApDH4Mhwm5Cz70D1RLTsmQe6vJkt_2E8mhyJuVF7yOmghoJQ8=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "보현커피 (BO HYUN Coffee)",
+        "uri": "https://maps.google.com/maps/contrib/101825584993305805085"
+      },
+      {
+        "displayName": "Yong Chung",
+        "uri": "https://maps.google.com/maps/contrib/110930874229939308722"
+      },
+      {
+        "displayName": "Thomas Borch",
+        "uri": "https://maps.google.com/maps/contrib/105452752025181778492"
+      },
+      {
+        "displayName": "BEE KIM",
+        "uri": "https://maps.google.com/maps/contrib/106683935268746501914"
+      }
+    ]
+  },
+  "3456e613-742a-81d7-b08d-dda44d80c230": {
+    "placeId": "ChIJd7iX2BCZfDURyF3y3oWJmGI",
+    "placeName": "Portrait coffeebar",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqHV0ZB0vrL1_RJtdlrDo7rqgZOTHgDWa0yOPKDmIpMDnJ_CcM-BEYE4Dz7Em1iV6R6HtWiVbz6gwsRLfCjqY8tkiwfr7W2Url4=s4800-w555",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN7FDsq0L1wuEO2zY4x9jXuyVHQW9jibF5VhkL8VG_EejfgHKC2vki6koiLpBCeFaSKbyrJjosYUAZcLOwafiiNXEqH8ISgEaktUuFsq5N0s6IdSPutmwrZmw0cdVaQ1f2lNLxjyndWKD1xGhcAoLHVHA=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqF9rplZyAbp0kl4Gp63T_64gigPhco2GcqmoLxdGs7a5b7PtP1MPIgQgE_Q3Ss3ZsrQrgVTXEPRvwrg9v0QCQLv3RN_DNBUPtM=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqFlLKPDIF_658OaNRCvfOwpPHIVyYOJQXNPJhEHc13p3rMMob-DnArck73AaLsldu6H55WS_O9I-ie5zjRgPKzb1EFQi8g2vII=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqGwP-W1ij0yaSpuwZiLluBkrtCOb-5JIWCJxPLpDbxoDjaS0MuvWPzQkZ1rel7kn1r6nQXS-S-R2RWAx5phTo0UDMjs4a-9XzE=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "Portrait coffeebar",
+        "uri": "https://maps.google.com/maps/contrib/117655452661769370578"
+      },
+      {
+        "displayName": "Holideez",
+        "uri": "https://maps.google.com/maps/contrib/100869257863584612957"
+      }
+    ]
+  },
+  "3456e613-742a-81e5-8e15-f523eaff7d4a": {
+    "placeId": "ChIJ38-YVEOjfDUR2qBrtEcLdMM",
+    "placeName": "업사이드커피 약수",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPGLDSVLLGBjqdZZJC7ZyzERf48bKtL4Ua_f12qd-vj8Hf7HyqjGvIzxMvEzLdRopQwalt_YdgNxUt_psK88v1_qpXvnVXsgepAx2erGs6Q6vhWFwNTU72gatQBZTHa6npOUJAePJV_nehW20Q=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqGJt8KR0qjsLNpzjzJ0UVI_-n70CiU4kHpY2Xslh2cMwfA3wXiy6wTjQUJAdzsTsL6eO-L-m0EQdJEhM7BY7D7Pn4iexFwCEq0=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO4uVArsJPAHjv4IBhi0jeLdiBHaKexSAvHZtdmM38t173FQzbM87LBjr5xRq2t0RP3JF8Ep3IYz0fwU8aSG_e6pqrhyMtIHkW5ir52ryoB2N-d2ToqgrJD1yHrANkjj4lQWQxx1brb4eOqoeAuybdENg=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNrag1mpw3TxRpimjMbl_hDYVRqZSU6wsLFU2wavy9Gtt2j3VDnP5nJE9UHXcs3jb9Tfzb7qs2dN7pRzV7uTd3O-W9EIEOuLdJGazfPGyhyG8J1LbCQ5sbnp_scg9VL4Wi5uDyoVcAErplTxdCq-7n1ag=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO5UJouMBiD3ZSlrFG31JiSXAvkTXnwFHG3QGdX8e61wXmXDsYEAK0Xgqq4Dw9e-RZscxIy2jZuqfwygvhCAju2uFJi6txDMq2if9CZIu_-uh4ZWkB_Kg_X133jMbzGGaZIrjgR3-naCA86yO73l4B3=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "이웅희",
+        "uri": "https://maps.google.com/maps/contrib/105087631170855011722"
+      },
+      {
+        "displayName": "업사이드커피 약수",
+        "uri": "https://maps.google.com/maps/contrib/113736958082101342975"
+      },
+      {
+        "displayName": "박세현",
+        "uri": "https://maps.google.com/maps/contrib/105454221258205604956"
+      },
+      {
+        "displayName": "이동현 (커넥터리)",
+        "uri": "https://maps.google.com/maps/contrib/117240882341854953168"
+      },
+      {
+        "displayName": "Sowupa",
+        "uri": "https://maps.google.com/maps/contrib/112141714725705538778"
+      }
+    ]
+  },
+  "3456e613-742a-81e7-a47a-e5cda7abe514": {
+    "placeId": "ChIJBQi0riGjfDURyIKWO02Rkc0",
+    "placeName": "챔프커피 을지로",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNWvpgkp3KX_oXfgqKz91fYJjxRh16VQbXO5sxnGjaJZQ4E7aU_y5mCS1_OF0yumd1q1WIkE4YYoZamvkAic0dacJKvwMqlcUddKxh5VIaGQu5bj5czJoU9XlriWFOclrrSj5f8QYnqi8MP288P1aJ20g=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZORff_9k2a_ynMozag6pswmbJvA6y6TLmTA0pwMcW3sGB9gb4xy5C8tlwDCLS5KKTNMpmk2lIc_1GbKEOaNd3k0tmhVPMNVGPm7e39cBZn5kDm1fkzFcf-RmF4UI3Wbm1tgVwLFpW-aK0ikqmc=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNF4Xj6WaUDVuk4LeY4wE5YHzdq_FMGmvb7S6OY2KL5RXvOQE0Jn5EP94yHYyfkiu8sIaLQzSukRpobrvZkQzlduQSltm1rYLvPt_1JIMQIlxX9l1PEXFAQc4I74DLOvZFgEdM6-IBWscDqdwfbhAxl=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOvVuuVEJKMB1TFhtwHgn6A19yPrtA_FNhGffmJtqJx_R6aFlnZoAfezjvkmQTkDUEY_vAtvRtXUM1OFoPPifZxqDlZ8-7_CtKo2IdYYDx3qp2YuD5okgTa48DGnHjbe0e17jKsikYxn-63EA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZO4dcxx5msH_ojgAZi_mSIfodZOznmfyALTak9LZ90gkV7o-VHlpW9Wj9OkWXlmFqd9wDvsgrheBeYLpI0WsU1hwAZkUVdbDuEg04HUyTpNAxz-un7WtWlaYzmr-V0ZPqUQpUVOX5XownngYr0TKHElSg=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "Troy Nam",
+        "uri": "https://maps.google.com/maps/contrib/109077213121368193973"
+      },
+      {
+        "displayName": "시래캔",
+        "uri": "https://maps.google.com/maps/contrib/113330853258777970160"
+      },
+      {
+        "displayName": "Lu pin",
+        "uri": "https://maps.google.com/maps/contrib/103191946365919722161"
+      },
+      {
+        "displayName": "小不點Paine",
+        "uri": "https://maps.google.com/maps/contrib/115521204432315046152"
+      }
+    ]
+  },
+  "3456e613-742a-81ec-a7e8-fc3e1001a29e": {
+    "placeId": "ChIJ01cNklGjfDUR_eyAQQVRV_0",
+    "placeName": "맥컬리커피",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqFnO3ToAZInMXVimYPISzXs0lO6lx9SqA2xAVu52Hw1lJ2V6V8tlENT1bbdS8bpmI69WbUuVyfVCsWtkEJ_2XmZFMkcksFZkOc=s4800-w800",
+      "https://lh3.googleusercontent.com/places/ANXAkqFw5tcc9A7LHMTbgyXvs3Ir6INXj2lT1-_SHuW7SXAhImRQSNdn1MsmhCfoX_K6neHvpX9IXTIOc4c6LvHytQk3oNTXNUiGhsA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNfsT7yey1TOfVfrlojBHSXKycTduNBlscPCq-tNNDMCpgcIjhk12pXydkyBc1MVaCsn41ika5BbckH4a5SvFdbvaXlT9aAeHQ2Ehsz6K0TsIVy8WOuf_Ik1QQd0MUVDmyI95L0aVotqTOaFqDXmzY9=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZN6-VllYGwM-ZA1ebxYjdG8W8Yh31vcp55HLcqqCaSq1yva05vSBJtgYfPRw4OXiHXr25QW31IAGbZ7G3TbudS2nuhnHFzxUiu_QdJzd27kNjh1zZ0joNlpUjJcaSPQOX97hs04Kbc3G5xvV1RTwJiUPQ=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZP6985M49UnQz8o_MvWbknVcbWmH_ECUJj-fupQ7hrcNzLF6lh9od8qsWDzAfRmFSjwC8rXQE4E-ugZ8nioA1pT275pX9AmwgSEyVinBkq6J_MtVhCNd1gOJTTF5dwiJFVxiXdYSLI3bT7QDw=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "맥컬리커피",
+        "uri": "https://maps.google.com/maps/contrib/112776837295624220563"
+      },
+      {
+        "displayName": "Winnie Lee",
+        "uri": "https://maps.google.com/maps/contrib/103607488160778828911"
+      },
+      {
+        "displayName": "Janine Pagtakhan",
+        "uri": "https://maps.google.com/maps/contrib/102432335726703941796"
+      }
+    ]
+  },
+  "3456e613-742a-81ee-ace8-c0d60cf1860f": {
+    "placeId": "ChIJvU0tYG2ZfDURGBNEtgO6e2E",
+    "placeName": "써밋컬쳐 신촌점",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/places/ANXAkqGHEyQbmHIUAMC4AR3ow2j5G4V-Rn1B9JDLTP0j1kttYjIeCIra1CT9E66adjwaHSxbSEu9wCzHe9aXx8Mfe7YWtq84Qant990=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZNiuoX5Bx0p-0wQaPReT_0mn9Vdw0SK8ic9RlGIRge9MQLyGxyh7hXN6-B4ZaVt6C-uLTyDBNyERyCZbWJlN6pZEd0wCfJMf-4ugZZ89h86FmgH1wNuIrh3eaBn27haV1Ismi1FrxyL3ieWnno=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPIzYZNg11yD78e5jgIqdBs-EvQMeGq3zysoQEClRmyt1NvKHecUfewRti7jHhlgdP6cf95RjBS26hoAaKroLAZRqCLdq7gI1XrdvfJEuM9WAVVS63U_cHUFu-bH0Gf3BKXiXPvC-nsymgqUA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMIHx4YVNS7HFPK8BoGeykZX9Q6LtGciQEHo9bAKtYKEOqoETqrQUpFCsv6wNjcfVa5vZRoKyMPooWj-x0dwKQbwvtGhz7n0l78ZZf9BN6xGa9MacPU35TZOWRTFHnGRKOPlmThK3ULvJnCLHE=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMoxX1QSjn8m6aGQ8X5TxOM0ln65z66S0dE_r4rLPLSUqa_o-k6M1pskoS4QOhfVP4dru9DHN9s8fH5lEnGVGZqJVek4eFD10ZqRsb51Mz1m0BqFFMtIWsWaSbFNURHGxb5JiYxLbUx0kPeZ14mfPfBMw=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "써밋컬쳐 신촌점",
+        "uri": "https://maps.google.com/maps/contrib/117990096595257196919"
+      },
+      {
+        "displayName": "박원재",
+        "uri": "https://maps.google.com/maps/contrib/104628043233507030228"
+      },
+      {
+        "displayName": "IAKOV PAK",
+        "uri": "https://maps.google.com/maps/contrib/103868824186246336228"
+      }
+    ]
+  },
+  "3456e613-742a-81f9-9628-e740514d4c20": {
+    "placeId": "ChIJmfIOVS-ZfDURdJutr7fX_yY",
+    "placeName": "딥블루레이크",
+    "photoUris": [
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOXoom62MK8N_m7T8xw9r_r6m30elu4Otmky-kBHx1faN1wLqoPnSJxK5ggQfATRy_4X0EcGj6DbFIHE725djstgqOsD8kBNoy_8D32CCPd6Quiaam5Hrdh6Y9ifZbXuaaJbj9VDKERBM3xq14=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPFdnBzUShwrktP7k8F1eLlJpABsjfWeXfrTAtHZLEgsYEU4ZdDeARgtUEpri5433uklU0MvCs70NdtepPYZiHyxM87JDJOImnFnojDGRGzhzk7hyjBnphhhHqOG3fzzHJHfeBygIZkfNqekA=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZMv-agOLPm7E8E_GRZoB27D1DAXVZ3LLrYV8IS6-fZec4FrCqxQ4-9la5Hbdpfo0hfQ_GgwMOwWWNM3H3Uu3ZQCyx2OXMpg0UBUMut9ry0pe8l_1crDFXTBpaGk20LLuS47nNOlA8Bj6ABPGBRRGFnF9g=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZOT4ouVY9hCwBuOex95yzTC2V8vhQhPdvtCD1YvhG3_l-bUHRNjd6525kCsSfk0m-O7mo_VYzOqxmN35byC7b_YvjPLFA-aBOjemVR6GvBX7Qj3mAiiVv-4u9xLYruKiiEMnOQfI8HC3FpEF0lIol_f-Q=s4800-w800",
+      "https://lh3.googleusercontent.com/place-photos/AJRVUZPal6wubao-zRXE1k55ERJjkZuO4hYiYNSEQ9IBu-Xxyfii532uj5MZ5QrdBCbKOAb7hL8X47uMzBqi9PhmQd8gOrjQRXZhztterxI71N4GcyommoEwVRcQBXJIrzoeOPidbp_wS_H6GM1a7hcOdHvEMA=s4800-w800"
+    ],
+    "attributions": [
+      {
+        "displayName": "히둥 heedoong",
+        "uri": "https://maps.google.com/maps/contrib/110139067500832058171"
+      },
+      {
+        "displayName": "Novia",
+        "uri": "https://maps.google.com/maps/contrib/111708720672506861891"
+      },
+      {
+        "displayName": "Jay",
+        "uri": "https://maps.google.com/maps/contrib/108669663780773449177"
+      },
+      {
+        "displayName": "B K",
+        "uri": "https://maps.google.com/maps/contrib/102736215150568380319"
+      },
+      {
+        "displayName": "Paul Leong",
+        "uri": "https://maps.google.com/maps/contrib/107174367799723961278"
+      }
+    ]
+  }
+}

--- a/public/data/recommend.json
+++ b/public/data/recommend.json
@@ -1,0 +1,245 @@
+{
+  "groups": [
+    {
+      "groupId": "group-awards",
+      "name": "수상 경력이 있는 카페",
+      "cafes": [
+        {
+          "id": "3456e613-742a-8105-a51b-f7ef853d6b45",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZNVzF3tI0t0FkJBkRM5mz4fi2xUIu6Cgv1hZcnp65lZtdcBsfy-l2GR7hQU6rVoJaP2h7cOM8H-xgVtDtYvvI6_zfPGF1Swt_KxRjN9WXLqhHpLG92ACM1fZwrkMxSzgXjOeFfeAZ-J2rHuyQ=s4800-w800",
+          "name": "트레머 커피웍스",
+          "nearestStation": "홍대입구"
+        },
+        {
+          "id": "3456e613-742a-810c-9314-c6c3dca0c7d0",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZMoDd1eUjM-E7MDr0eLoMPgHxMs83lDUq_dxusWDfbRcOvm2EPMu6poLZ7rC4OvmVhQTuuv7-2XQf9RVssrH5qdr6UbzRNbgJSvUmmto_CcDs81-80qb9uXZDtyqm7Kwh2qD9eEpmPis8fAqA=s4800-w800",
+          "name": "커넥츠커피 망원",
+          "nearestStation": "망원"
+        },
+        {
+          "id": "3456e613-742a-8112-9bcd-d1a2b77758c2",
+          "mainImage": "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220416_166%2F1650082800337GAMGh_JPEG%2FLOTUS_%25BF%25F8%25C7%25FC%25B5%25F0%25C0%25DA%25C0%25CE01.jpg",
+          "name": "로투스 로스팅랩",
+          "nearestStation": "신당"
+        },
+        {
+          "id": "3456e613-742a-8117-998a-e76b75241b88",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZNp3w0uyaLAXXoned2nURVQL8iMBiH08O61of7a6sdd6n2vxJjYjH9sJFJtCs2joCfiZbYOeb-k35Rx6nfzCsbpYzvYUeW8v9bWM09q-P8A4NPVdvSmjIQtDbb9jwe1uChdSrbbpCzcb1eF=s4800-w800",
+          "name": "커피한약방",
+          "nearestStation": "을지로3가"
+        },
+        {
+          "id": "3456e613-742a-8158-b139-d5dee62905dd",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZMr_c7bS_U5cIe8Raiv-ovMROHncOhtuivN5GThAmtPjXazAUpYNFZbg2UaNUw898di99RWdgl3lgio3Z-x8POaBeWCGzrJX6QuG2_vO7bpQl_pzNVSJMe5yriLvwjsEaw7KnASxn14xCIml3s=s4800-w800",
+          "name": "인덴트커피룸",
+          "nearestStation": "망원"
+        },
+        {
+          "id": "3456e613-742a-815b-90d7-ef91d85b98aa",
+          "mainImage": "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240725_30%2F1721862842184CIHxq_JPEG%2FIMG_5388.jpeg",
+          "name": "말릭커피",
+          "nearestStation": "홍대입구"
+        },
+        {
+          "id": "3456e613-742a-8168-a4f1-cc45f6b820d2",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZNXconVpn4gyBNZ_PVV2ZrXWvl6vPqE8EDA3c99o9NQfvD6CziB6xznE2VgHCnfhp95ezCYUX4D8Z-Yhx_iA9Vi9Z0onZ3IbuRj03ae0nhHz8Lvhfmp5ISJdD4nA-0Jgu9ryzh6LjQV5o9rQg=s4800-w800",
+          "name": "헤베커피",
+          "nearestStation": "충무로"
+        },
+        {
+          "id": "3456e613-742a-8198-bb10-d841006daf57",
+          "mainImage": "",
+          "name": "노띵커피 본점",
+          "nearestStation": "동대입구"
+        },
+        {
+          "id": "3456e613-742a-81a4-a35a-cfc0bd4c8aec",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZO-KO_p-yiiYdw4fXxXp9MR3Fu_nSvQNv6vr2wFyKisy8ct_ZFGuTvp_HFuCruSVwC37c69hh5Zt7tvDDp6XNZmdDcYM0hffXFmfemktjELbF4uo5uCPZKo0_ngtBJGRHPM8Xg3CN13V8omPNY=s4800-w800",
+          "name": "커피그래",
+          "nearestStation": "약수"
+        },
+        {
+          "id": "3456e613-742a-81b4-903d-ea20420b9a3f",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZN62RQ1FnwvGKUmwr2fz9oqNtG5yj66k2NZPOdDAfxP3dr1j2xdu5liLLeGrienmwhFgRoKNbE9YMKCVFJagsN-12bdWsGIZjc96rL-UtLkgbWD1XSds3DArBnFPi0HEFpKJqnb4wCYh8qji9k=s4800-w800",
+          "name": "커피친구",
+          "nearestStation": "종각"
+        }
+      ]
+    },
+    {
+      "groupId": "group-acidity",
+      "name": "산미있는 커피에 도전하고 싶다면",
+      "cafes": [
+        {
+          "id": "3456e613-742a-8112-9bcd-d1a2b77758c2",
+          "mainImage": "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20220416_166%2F1650082800337GAMGh_JPEG%2FLOTUS_%25BF%25F8%25C7%25FC%25B5%25F0%25C0%25DA%25C0%25CE01.jpg",
+          "name": "로투스 로스팅랩",
+          "nearestStation": "신당"
+        },
+        {
+          "id": "3456e613-742a-8121-a957-fc1f5cb28894",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZO4N7B2-f52cmt-tYwM42IITAf5LFPG74_8I3Py3HgY9_39QMy-pu9Y8SOGVm47H3q3QvvNnBGYPotci5C3JD534Du-ZCdR80LaAcfGUAY3cutmdWMBwPO_1v1ZZl-fmGeg6AywsTZVJVIG8ys=s4800-w800",
+          "name": "펠트커피 청계천점",
+          "nearestStation": "광화문"
+        },
+        {
+          "id": "3456e613-742a-812e-b998-ecb84f92fe35",
+          "mainImage": "https://lh3.googleusercontent.com/places/ANXAkqEF3B7WteHj1IhJfhJ3g-DM8r4pTmdhoXDdjpjVvb8GNg_7ZxtEN-g3yn7OxFbSknMiSRUijdesImFveGx9uYGjCmLXyx33bRo=s4800-w800",
+          "name": "평형",
+          "nearestStation": "망원"
+        },
+        {
+          "id": "3456e613-742a-8169-99e7-f8434bb3c01d",
+          "mainImage": "",
+          "name": "플레이백",
+          "nearestStation": "충무로"
+        },
+        {
+          "id": "3456e613-742a-8170-962e-d3f534d87546",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZM4TiaZ1Up8pWG1c2N83yN1ilG6kC-cA6JrnswqIkkkt4DmisQgfeHBTZgctXhJ6ki-d8MPy5nWM07GQ8c9kzdCrhN2g85EHgmg85USaNa1b_kdN3-3yykEVvopKfIbSONlzCA8SjdacSMSA7uwhqNRKA=s4800-w800",
+          "name": "펠트커피 광화문점",
+          "nearestStation": "광화문"
+        },
+        {
+          "id": "3456e613-742a-81d7-b08d-dda44d80c230",
+          "mainImage": "https://lh3.googleusercontent.com/places/ANXAkqHV0ZB0vrL1_RJtdlrDo7rqgZOTHgDWa0yOPKDmIpMDnJ_CcM-BEYE4Dz7Em1iV6R6HtWiVbz6gwsRLfCjqY8tkiwfr7W2Url4=s4800-w555",
+          "name": "포트레이트커피바",
+          "nearestStation": "망원"
+        }
+      ]
+    },
+    {
+      "groupId": "group-latte",
+      "name": "시그니처 라떼 맛집",
+      "cafes": [
+        {
+          "id": "3456e613-742a-810c-9314-c6c3dca0c7d0",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZMoDd1eUjM-E7MDr0eLoMPgHxMs83lDUq_dxusWDfbRcOvm2EPMu6poLZ7rC4OvmVhQTuuv7-2XQf9RVssrH5qdr6UbzRNbgJSvUmmto_CcDs81-80qb9uXZDtyqm7Kwh2qD9eEpmPis8fAqA=s4800-w800",
+          "name": "커넥츠커피 망원",
+          "nearestStation": "망원"
+        },
+        {
+          "id": "3456e613-742a-812f-8185-f5e79c36f5e6",
+          "mainImage": "https://lh3.googleusercontent.com/places/ANXAkqG4Q9pfPVDTyNmQKTb0mLFHLDFSUGFLQUfshfnCA-hOyMJU5a3FNXoCURoydMXYqxfA5CjUHjDfp6R_gxew8xkGCdeWs5j_Yss=s4800-w800",
+          "name": "커피스니퍼 서울시청점",
+          "nearestStation": "시청"
+        },
+        {
+          "id": "3456e613-742a-815b-90d7-ef91d85b98aa",
+          "mainImage": "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240725_30%2F1721862842184CIHxq_JPEG%2FIMG_5388.jpeg",
+          "name": "말릭커피",
+          "nearestStation": "홍대입구"
+        },
+        {
+          "id": "3456e613-742a-8166-b916-fc0d662dea42",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZPDoub3urTpzKT3Dk-yR6ieyZxVA_MpYc-FXUH2vcrK9r5zvwgL63u0yo9HjBL98HFdNDSZfTLaziMjdiEClbfEbyAurQT9vyluQoh0JtU6-wK596VLu6EDbr9yHGOM0Di2TWnH3WtGoNAQ-mw=s4800-w800",
+          "name": "히트커피로스터스 서교",
+          "nearestStation": "홍대입구"
+        },
+        {
+          "id": "3456e613-742a-816b-901c-e41c2416734d",
+          "mainImage": "https://lh3.googleusercontent.com/places/ANXAkqFPQuvDl30fQfYvO9k2QZUoroD9KYzrlZ3YUo22BGWleoVGH5z7H_9QWG8GLEGh_R_IMmwrv7us1vInVlWyctUP-kW4Vz_-fpQ=s4800-w800",
+          "name": "퀜치커피",
+          "nearestStation": "망원"
+        },
+        {
+          "id": "3456e613-742a-819b-93ff-c4e48531760e",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZOe7IBy25Y9LS2R6ecttPbvDAXIz9mN9gErwTqCnPQAfiIjXklqMcYLUtMDhIPHRNLv1oqTQLLxSDHJRWPzLnKUUFRFym1v25s6Ew0TyP-8tfhfYgI9Cooapws00ph0zGooCjDrake_uV1v=s4800-w800",
+          "name": "섹터커피로스터스 본점",
+          "nearestStation": "충무로"
+        },
+        {
+          "id": "3456e613-742a-81e5-8e15-f523eaff7d4a",
+          "mainImage": "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20230629_8%2F1688001957512bTny5_JPEG%2FIMG_1839.jpeg",
+          "name": "업사이드커피 약수점",
+          "nearestStation": "약수"
+        },
+        {
+          "id": "3456e613-742a-81e7-a47a-e5cda7abe514",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZNWvpgkp3KX_oXfgqKz91fYJjxRh16VQbXO5sxnGjaJZQ4E7aU_y5mCS1_OF0yumd1q1WIkE4YYoZamvkAic0dacJKvwMqlcUddKxh5VIaGQu5bj5czJoU9XlriWFOclrrSj5f8QYnqi8MP288P1aJ20g=s4800-w800",
+          "name": "챔프커피 제3작업실",
+          "nearestStation": "을지로3가"
+        },
+        {
+          "id": "3456e613-742a-81ec-a7e8-fc3e1001a29e",
+          "mainImage": "https://lh3.googleusercontent.com/places/ANXAkqFnO3ToAZInMXVimYPISzXs0lO6lx9SqA2xAVu52Hw1lJ2V6V8tlENT1bbdS8bpmI69WbUuVyfVCsWtkEJ_2XmZFMkcksFZkOc=s4800-w800",
+          "name": "맥컬리커피",
+          "nearestStation": "을지로3가"
+        },
+        {
+          "id": "3456e613-742a-81f9-9628-e740514d4c20",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZOXoom62MK8N_m7T8xw9r_r6m30elu4Otmky-kBHx1faN1wLqoPnSJxK5ggQfATRy_4X0EcGj6DbFIHE725djstgqOsD8kBNoy_8D32CCPd6Quiaam5Hrdh6Y9ifZbXuaaJbj9VDKERBM3xq14=s4800-w800",
+          "name": "딥블루레이크",
+          "nearestStation": "망원"
+        }
+      ]
+    },
+    {
+      "groupId": "group-brand",
+      "name": "실패없는 브랜드 커피",
+      "cafes": [
+        {
+          "id": "3456e613-742a-810c-acae-d08ae2fbcf73",
+          "mainImage": "https://lh3.googleusercontent.com/places/ANXAkqE5eHmZGdw7P5_mCUk3g9v8IZy0-e2QYQIOAZ8ovRwjQdCXGol3vPPVem5rwMYQiuWpxk-KWFS0WbGbbswxQX-D1w_FuxjD-Xo=s4800-w800",
+          "name": "커피리브레 파란점",
+          "nearestStation": "홍대입구"
+        },
+        {
+          "id": "3456e613-742a-811c-b069-cda489e0a9dc",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZN9AX14pFZwXCu7y_revxvj42dbrGXbAU1_o1ELnYF2J85R_YeIgiHjWNW8CXdnSwc80ajJikaImOL_Bq_H5-QcN0tMVVb0BUhu1D91SkP8o6vSYopvffM3Wi3Y0rNf7ySeMokdkfAOykfz=s4800-w800",
+          "name": "아마츄어작업실 청계점",
+          "nearestStation": "을지로3가"
+        },
+        {
+          "id": "3456e613-742a-8121-a957-fc1f5cb28894",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZO4N7B2-f52cmt-tYwM42IITAf5LFPG74_8I3Py3HgY9_39QMy-pu9Y8SOGVm47H3q3QvvNnBGYPotci5C3JD534Du-ZCdR80LaAcfGUAY3cutmdWMBwPO_1v1ZZl-fmGeg6AywsTZVJVIG8ys=s4800-w800",
+          "name": "펠트커피 청계천점",
+          "nearestStation": "광화문"
+        },
+        {
+          "id": "3456e613-742a-812f-8185-f5e79c36f5e6",
+          "mainImage": "https://lh3.googleusercontent.com/places/ANXAkqG4Q9pfPVDTyNmQKTb0mLFHLDFSUGFLQUfshfnCA-hOyMJU5a3FNXoCURoydMXYqxfA5CjUHjDfp6R_gxew8xkGCdeWs5j_Yss=s4800-w800",
+          "name": "커피스니퍼 서울시청점",
+          "nearestStation": "시청"
+        },
+        {
+          "id": "3456e613-742a-8138-9e91-ed9e1a3863fc",
+          "mainImage": "https://lh3.googleusercontent.com/places/ANXAkqEh9OZOx1OceUcsEuQIUuFZc1Ow4oBmgBv0QlV0rLL8V0O-MPVeDYjGKEKHk5cOJnxs4htFl7QdLYPN2IL4slRyOgyOjwWVrEU=s4800-w800",
+          "name": "알레그리아 광화문 케이스퀘어시티점",
+          "nearestStation": "광화문"
+        },
+        {
+          "id": "3456e613-742a-8147-8641-e38b38b62205",
+          "mainImage": "https://search.pstatic.net/common/?src=https%3A%2F%2Fldb-phinf.pstatic.net%2F20240402_172%2F1712037942572gsrLk_JPEG%2F1.jpg",
+          "name": "프릳츠 원서점",
+          "nearestStation": "안국"
+        },
+        {
+          "id": "3456e613-742a-814b-9c2b-e3e9a61d55db",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZNvK4UkiWYztGWTEesgXSS1m6xM701GReDczssoBSsX4OuBrpvB5ZauF0OFxJ9aIoqWHEBO0zTyVfZ7rr6azqfElHOyCCC1PChRB_mVy343i2lm6wQsVvuTxmjqrA8LXkAnLDe-dJsmAYfr27kqj81VVA=s4800-w800",
+          "name": "블루보틀 홍대",
+          "nearestStation": "홍대입구"
+        },
+        {
+          "id": "3456e613-742a-8154-afb6-d508a5bb3d47",
+          "mainImage": "https://lh3.googleusercontent.com/places/ANXAkqGWpUdkX0HYEVtbM45bFI1nv0xi0tx1RYm56C_04VKwmTYQByWjQCDHFqzrVKSkw5BEQaVGhH1TqMxVQ1Fk1q_z04ZDUIkB-x8=s4800-w800",
+          "name": "커피리브레 명동성당점",
+          "nearestStation": "을지로3가"
+        },
+        {
+          "id": "3456e613-742a-8166-b916-fc0d662dea42",
+          "mainImage": "https://lh3.googleusercontent.com/place-photos/AJRVUZPDoub3urTpzKT3Dk-yR6ieyZxVA_MpYc-FXUH2vcrK9r5zvwgL63u0yo9HjBL98HFdNDSZfTLaziMjdiEClbfEbyAurQT9vyluQoh0JtU6-wK596VLu6EDbr9yHGOM0Di2TWnH3WtGoNAQ-mw=s4800-w800",
+          "name": "히트커피로스터스 서교",
+          "nearestStation": "홍대입구"
+        },
+        {
+          "id": "3456e613-742a-8167-bbe7-c86d5dccf82f",
+          "mainImage": "https://lh3.googleusercontent.com/places/ANXAkqGyGqDQbJb993TUV-2L7zwgt1aNVW20Xb2gp3-2bwBsLo3frLLaVSJZzKpZu_ZiZrWicVd67KSreXEV-XxYykQWVcm3jxQ0_n0=s4800-w800",
+          "name": "로스팅마스터즈 본점",
+          "nearestStation": "홍대입구"
+        }
+      ]
+    }
+  ],
+  "hasNext": false
+}

--- a/src/apis/cafeDetail.ts
+++ b/src/apis/cafeDetail.ts
@@ -8,12 +8,12 @@ interface CafeDetail extends Cafe {
   mainImageUrl: string[];
   reasonForSelection: string;
 }
-interface CafeDetailResponse {
+export interface CafeDetailResponse {
   cafe: CafeDetail;
   coffeeBean: CoffeeBean;
   menus: Menu[];
   tags: Tag[];
-  updatedAt: string;
+  updatedAt: string | null;
   description: string;
 }
 

--- a/src/app/(withNav)/cafes/page.tsx
+++ b/src/app/(withNav)/cafes/page.tsx
@@ -1,8 +1,8 @@
-import { getCafeRegions } from '@/apis/cafe';
 import CafesPage from '@/components/cafes/CafesPage';
+import { getRegionsFromData } from '@/lib/cafeData';
 
-export default async function Page() {
-  const regions = await getCafeRegions();
+export default function Page() {
+  const regions = getRegionsFromData();
 
   return <CafesPage availableRegions={regions} />;
 }

--- a/src/app/(withoutNav)/cafes/[id]/page.tsx
+++ b/src/app/(withoutNav)/cafes/[id]/page.tsx
@@ -1,5 +1,4 @@
-import { getCafes } from '@/apis/cafe';
-import { getCafeDetail } from '@/apis/cafeDetail';
+import { getCafeDetailFromData, getCafeListFromData } from '@/lib/cafeData';
 import ChevronLeft from '@/assets/Icon/Chevron_Left.svg';
 import BackButton from '@/components/cafes/[id]/BackButton';
 import BookMarkButton from '@/components/cafes/[id]/BookMarkButton';
@@ -11,7 +10,6 @@ import MapButton from '@/components/cafes/[id]/MapButton';
 import MenuList from '@/components/cafes/[id]/MenuList';
 import OriginList from '@/components/cafes/[id]/OriginList';
 import { RoastingBar } from '@/components/cafes/[id]/RoastingBar';
-import { CAFE_DETAIL_REVALIDATE_TIME } from '@/constants/revalidateTime';
 import {
   beanCardTitle,
   cafesDetailMain,
@@ -36,9 +34,12 @@ interface PageId {
   id: string;
 }
 
-export async function generateStaticParams(): Promise<PageId[]> {
-  const cafesResponse = await getCafes();
-  const { cafes } = cafesResponse;
+// 미리 생성된 id 만 유효 — 나머지는 404. 런타임에 없는 detail JSON 을 import 하지 않게 한다.
+// 데이터는 레포에 커밋된 정적 JSON 이라 런타임 revalidate 불필요 — 재배포 때 갱신된다.
+export const dynamicParams = false;
+
+export function generateStaticParams(): PageId[] {
+  const { cafes } = getCafeListFromData();
   return cafes.map((cafe) => ({
     id: cafe.cafeId,
   }));
@@ -47,10 +48,8 @@ export async function generateStaticParams(): Promise<PageId[]> {
 export default async function Page({ params }: { params: Promise<PageId> }) {
   const detailPageId = (await params).id;
 
-  const { cafe, coffeeBean, menus, updatedAt, tags } = await getCafeDetail(
-    detailPageId,
-    CAFE_DETAIL_REVALIDATE_TIME
-  );
+  const { cafe, coffeeBean, menus, updatedAt, tags } =
+    await getCafeDetailFromData(detailPageId);
 
   const blurDataUrl = await getBlurImg(cafe.mainImageUrl[0]);
 

--- a/src/components/cafes/[id]/Footer/index.tsx
+++ b/src/components/cafes/[id]/Footer/index.tsx
@@ -1,10 +1,10 @@
 import { FooterBox, updateDate, updateText } from './Footer.css';
 
-const Footer = ({ updatedDate }:{updatedDate:string}) => {
-  const date = updatedDate.replaceAll('-', '.');
+const Footer = ({ updatedDate }: { updatedDate: string | null }) => {
+  const date = updatedDate?.replaceAll('-', '.');
   return (
     <footer className={FooterBox}>
-      <div className={updateDate}>{`정보 업데이트 날짜 ${date}`}</div>
+      {date && <div className={updateDate}>{`정보 업데이트 날짜 ${date}`}</div>}
       <div className={updateText}>메뉴와 원두는 각 매장의 사정에 따라 기재된 내용과 다를 수 있습니다. </div>
     </footer>
   );

--- a/src/lib/cafeData.ts
+++ b/src/lib/cafeData.ts
@@ -1,0 +1,31 @@
+import type { CafeListResponse, CafeRegion } from '@/apis/cafe';
+import type { CafeDetailResponse } from '@/apis/cafeDetail';
+import cafesJson from '../../public/data/cafes.json';
+import areasJson from '../../public/data/areas.json';
+
+/**
+ * SSG/빌드용 데이터 접근 — public/data 의 정적 JSON 을 직접 읽는다.
+ * 클라이언트 런타임 fetch(`@/apis/*`)와 달리 HTTP·외부 서버에 의존하지 않으므로
+ * `next build`(generateStaticParams·서버 컴포넌트)가 자급자족으로 통과한다.
+ */
+
+const REGION_ALL: CafeRegion = { displayName: '전체', code: '' };
+
+export function getCafeListFromData(): CafeListResponse {
+  return {
+    cafes: cafesJson as unknown as CafeListResponse['cafes'],
+    hasNext: false,
+  };
+}
+
+export function getRegionsFromData(): CafeRegion[] {
+  const { areas } = areasJson as { areas: CafeRegion[] };
+  return [REGION_ALL, ...areas];
+}
+
+export async function getCafeDetailFromData(id: string): Promise<CafeDetailResponse> {
+  // 템플릿 리터럴 import → 번들러가 details/*.json 전체를 컨텍스트로 포함시켜
+  // 빌드·런타임 모두 fs 없이 동작한다 (Vercel serverless에서도 안전).
+  const mod = await import(`../../public/data/details/${id}.json`);
+  return (mod.default ?? mod) as CafeDetailResponse;
+}

--- a/src/lib/getBlurImage.ts
+++ b/src/lib/getBlurImage.ts
@@ -1,9 +1,19 @@
 import { getPlaiceholder } from 'plaiceholder';
 
+// 1x1 투명 PNG — 이미지를 못 받아왔을 때 placeholder="blur" 가 요구하는 유효한 blurDataURL 폴백.
+const FALLBACK_BLUR =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
 const getBlurImg = async (imgSrc: string): Promise<string> => {
-  const buffer = await fetch(imgSrc).then(async (res) => Buffer.from(await res.arrayBuffer()));
-  const { base64 } = await getPlaiceholder(buffer);
-  return base64;
+  try {
+    const buffer = await fetch(imgSrc).then(async (res) => Buffer.from(await res.arrayBuffer()));
+    const { base64 } = await getPlaiceholder(buffer);
+    return base64;
+  } catch {
+    // 빌드 시점에 외부 이미지(예: 만료된 Google Photos URL)를 못 받아도
+    // 페이지 전체 빌드가 깨지지 않도록 폴백 반환.
+    return FALLBACK_BLUR;
+  }
 };
 
 export default getBlurImg;


### PR DESCRIPTION
## 작업 내용

빌드 시점에 죽은 `NEXT_PUBLIC_BACKEND_URL` 서버로 fetch하던 SSG 경로를 `public/data` JSON **직접 읽기**로 전환해 `next build`를 자급자족하게 만들었다.

- `src/lib/cafeData.ts` — list/detail/areas JSON 직접 접근 (detail은 동적 import로 번들)
- `/cafes/[id]` — `generateStaticParams`·`Page`를 직접 읽기로, `dynamicParams=false`
- `/cafes` — 지역 목록 직접 읽기 (서버 컴포넌트 빌드 fetch 제거)
- `getBlurImage` — 죽은 이미지 URL 방어 (유효한 폴백 blurDataURL)
- `Footer`/`CafeDetailResponse` — `updatedAt: null` 안전 처리 (빌드 크래시 수정)
- `public/data` 레포 커밋 (cafes-raw.json 제외)

## 검증

- 로컬 `next build` 통과: `/cafes/[id]` 46개 경로 SSG 프리렌더, `/cafes` 정적, 외부 서버 의존 없음.

## 범위 / 후속

- Phase 1 (이 PR): 빌드 자급자족 → CI #80 unblock.
- Phase 2 (후속): 클라이언트 런타임 fetch(react-query 무한스크롤·추천)를 `/api/v1` 라우트로 연결. 그 전까진 홈/리스트의 클라 데이터는 비어 보일 수 있음(서버 다운).

## 연관 이슈

- close #83